### PR TITLE
Make it work on linux (and still work on Mac OS)

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,21 +1,26 @@
 extern mod fuse;
 
 use std::libc::{c_int, mode_t, off_t, size_t, ENOENT, S_IFDIR, S_IFREG};
+use std::default::Default;
 
 struct HelloFS;
 
 static hello_world: &'static str = "Hello World!\n";
-static hello_dir_attr: fuse::fuse_attr = fuse::fuse_attr {
-	ino: 1, size: 0,  blocks: 0, atime: 0, mtime: 0, ctime: 0, crtime: 0, atimensec: 0, mtimensec: 0, ctimensec: 0, crtimensec: 0, mode: S_IFDIR as u32|493, nlink: 2, uid: 501, gid: 20, rdev: 0, flags: 0
-};
-static hello_txt_attr: fuse::fuse_attr = fuse::fuse_attr {
-	ino: 2, size: 13, blocks: 0, atime: 0, mtime: 0, ctime: 0, crtime: 0, atimensec: 0, mtimensec: 0, ctimensec: 0, crtimensec: 0, mode: S_IFREG as u32|420, nlink: 1, uid: 501, gid: 20, rdev: 0, flags: 0
-};
+fn hello_dir_attr() -> fuse::fuse_attr { 
+	fuse::fuse_attr {
+		ino: 1, mode: S_IFDIR as u32|493, nlink: 2, uid: 501, gid: 20, ..Default::default()
+	}
+}
+fn hello_txt_attr() -> fuse::fuse_attr {
+	fuse::fuse_attr {
+		ino: 2, size: 13, mode: S_IFREG as u32|420, nlink: 1, uid: 501, gid: 20, ..Default::default()
+	}
+}
 
 impl fuse::Filesystem for HelloFS {
 	fn lookup (&mut self, parent: u64, name: &str) -> Result<~fuse::fuse_entry_out, c_int> {
 		if parent == 1 && name == "hello.txt" {
-			Ok(~fuse::fuse_entry_out { nodeid: 2, generation: 0, attr: hello_txt_attr, entry_valid: 1, entry_valid_nsec: 0, attr_valid: 1, attr_valid_nsec: 0 })
+			Ok(~fuse::fuse_entry_out { nodeid: 2, generation: 0, attr: hello_txt_attr(), entry_valid: 1, entry_valid_nsec: 0, attr_valid: 1, attr_valid_nsec: 0 })
 		} else {
 			Err(ENOENT)
 		}
@@ -23,8 +28,8 @@ impl fuse::Filesystem for HelloFS {
 
 	fn getattr (&mut self, ino: u64) -> Result<~fuse::fuse_attr_out, c_int> {
 		match ino {
-			1 => Ok(~fuse::fuse_attr_out { attr_valid: 1, attr_valid_nsec: 0, dummy: 0, attr: hello_dir_attr }),
-			2 => Ok(~fuse::fuse_attr_out { attr_valid: 1, attr_valid_nsec: 0, dummy: 0, attr: hello_txt_attr }),
+			1 => Ok(~fuse::fuse_attr_out { attr_valid: 1, attr_valid_nsec: 0, dummy: 0, attr: hello_dir_attr() }),
+			2 => Ok(~fuse::fuse_attr_out { attr_valid: 1, attr_valid_nsec: 0, dummy: 0, attr: hello_txt_attr() }),
 			_ => Err(ENOENT),
 		}
 	}
@@ -41,9 +46,9 @@ impl fuse::Filesystem for HelloFS {
 		if ino == 1 {
 			let mut buffer = buffer;
 			if offset == 0 {
-				buffer.fill(1, 0, hello_dir_attr.mode as mode_t, ".");
-				buffer.fill(1, 1, hello_dir_attr.mode as mode_t, "..");
-				buffer.fill(2, 2, hello_txt_attr.mode as mode_t, "hello.txt");
+				buffer.fill(1, 0, hello_dir_attr().mode as mode_t, ".");
+				buffer.fill(1, 1, hello_dir_attr().mode as mode_t, "..");
+				buffer.fill(2, 2, hello_txt_attr().mode as mode_t, "hello.txt");
 			}
 			Ok(buffer)
 		} else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,12 @@ use session::{Session, BackgroundSession};
 
 // Re-export types used in results of filesystem operations
 pub use native::{fuse_attr, fuse_kstatfs, fuse_file_lock, fuse_entry_out, fuse_attr_out};
-pub use native::{fuse_getxtimes_out, fuse_setattr_in, fuse_open_out, fuse_write_out};
+pub use native::{fuse_setattr_in, fuse_open_out, fuse_write_out};
 pub use native::{fuse_statfs_out, fuse_getxattr_out, fuse_lk_out, fuse_bmap_out};
 pub use native::consts;
+#[cfg(target_os = "macos")]
+pub use native::{fuse_getxtimes_out};
+
 pub use sendable::DirBuffer;
 
 /// Filesystem trait.

--- a/src/native.rs
+++ b/src/native.rs
@@ -44,6 +44,7 @@ pub static FUSE_KERNEL_MINOR_VERSION: u32 = 8;
 pub static FUSE_ROOT_ID: u64 = 1;
 
 #[cfg(target_os = "macos")]
+#[deriving(Default)]
 pub struct fuse_attr {
 	ino: u64,
 	size: u64,
@@ -65,6 +66,7 @@ pub struct fuse_attr {
 }
 
 #[cfg(target_os = "linux")]
+#[deriving(Default)]
 pub struct fuse_attr {
 	ino: u64,
 	size: u64,

--- a/src/request.rs
+++ b/src/request.rs
@@ -17,8 +17,14 @@ use session::Session;
 /// Maximum write size. FUSE recommends at least 128k, max 16M. Default on OS X is 16M.
 static MAX_WRITE_SIZE: u32 = 16*1024*1024;
 
+#[cfg(target_os = "macos")]
 /// We support async reads and our filesystems are usually case-insensitive
+/// TODO: should case sensitivity be an option passable by the implementing FS?
 static INIT_FLAGS: u32 = FUSE_ASYNC_READ | FUSE_CASE_INSENSITIVE;
+
+#[cfg(not(target_os = "macos"))]
+/// We support async reads
+static INIT_FLAGS: u32 = FUSE_ASYNC_READ;
 
 /// Request data structure
 pub struct Request {
@@ -43,7 +49,6 @@ impl Request {
 			res
 		}
 	}
-
 	/// Dispatch request to the given filesystem.
 	/// This parses a previously read request, calls the appropriate
 	/// filesystem operation method and sends back the returned reply
@@ -243,9 +248,12 @@ impl Request {
 				let name = data.fetch_str();
 				let value = data.fetch_data();
 				assert!(value.len() == arg.size as uint);
-				// FIXME: arg.position exists on OS X only, use 0 on other OS
 				debug2!("SETXATTR({:u}) ino {:#018x}, name {:s}, size {:u}, flags {:#x}", header.unique, header.nodeid, name, arg.size, arg.flags);
-				self.reply(ch, se.filesystem.setxattr(header.nodeid, name, value, arg.flags as uint, arg.position as off_t));
+				#[cfg(target_os = "macos")]
+				fn get_position(arg:&fuse_setxattr_in) -> off_t { arg.position as off_t }
+				#[cfg(not(target_os = "macos"))]
+				fn get_position(_arg:&fuse_setxattr_in) -> off_t { 0 }
+				self.reply(ch, se.filesystem.setxattr(header.nodeid, name, value, arg.flags as uint, get_position(arg)));
 			},
 			FUSE_GETXATTR => {
 				let arg: &fuse_getxattr_in = data.fetch();
@@ -289,10 +297,23 @@ impl Request {
 				debug2!("BMAP({:u}) ino {:#018x}, blocksize {:u}, ids {:u}", header.unique, header.nodeid, arg.blocksize, arg.block);
 				self.reply(ch, se.filesystem.bmap(header.nodeid, arg.blocksize as size_t, arg.block));
 			},
-			FUSE_SETVOLNAME => {			// OS X only
+			op if self.dispatch_macos_only(op, se, header, ch, &mut data) => (),
+			_ => {
+				warn2!("Ignoring unsupported FUSE operation {:u}", header.opcode)
+				self.reply_error(ch, ENOSYS);
+			},
+		}
+	}
+
+	/// Handle MacOS-only commands.  Return true if the command was handled
+	#[cfg(target_os = "macos")]
+	fn dispatch_macos_only<FS: Filesystem> (&self, opcode: fuse_opcode, se: &mut Session<FS>, header: &fuse_in_header, ch: Channel, data: &mut ArgumentIterator) -> bool {
+		match opcode {
+			FUSE_SETVOLNAME => {
 				let name = data.fetch_str();
 				debug2!("SETVOLNAME({:u}) name {:s}", header.unique, name);
 				self.reply(ch, se.filesystem.setvolname(name));
+				true
 			},
 			FUSE_EXCHANGE => {				// OS X only
 				let arg: &fuse_exchange_in = data.fetch();
@@ -300,18 +321,18 @@ impl Request {
 				let newname = data.fetch_str();
 				debug2!("EXCHANGE({:u}) parent {:#018x}, name {:s}, newparent {:#018x}, newname {:s}, options {:#x}", header.unique, arg.olddir, oldname, arg.newdir, newname, arg.options);
 				self.reply(ch, se.filesystem.exchange(arg.olddir, oldname, arg.newdir, newname, arg.options as uint));
+				true
 			},
 			FUSE_GETXTIMES => {				// OS X only
 				debug2!("GETXTIMES({:u}) ino {:#018x}", header.unique, header.nodeid);
 				self.reply(ch, se.filesystem.getxtimes(header.nodeid));
-			},
-
-			_ => {
-				warn2!("Ignoring unsupported FUSE operation {:u}", header.opcode)
-				self.reply_error(ch, ENOSYS);
-			},
+				true
+			}
+			_ => false
 		}
 	}
+	#[cfg(not(target_os = "macos"))]
+	fn dispatch_macos_only<FS: Filesystem> (&self, _opcode: fuse_opcode, _se: &mut Session<FS>, _header:&fuse_in_header, _ch: Channel, _data:&mut ArgumentIterator) -> bool { false }
 
 	/// Reply to a request with the given error code and data
 	fn send<T: Sendable> (&self, ch: Channel, err: c_int, data: &T) {

--- a/src/sendable.rs
+++ b/src/sendable.rs
@@ -4,9 +4,11 @@
 
 use std::{cast, ptr, sys, vec};
 use std::libc::{mode_t, off_t, S_IFMT};
-use native::{fuse_entry_out, fuse_attr_out, fuse_getxtimes_out, fuse_open_out};
+use native::{fuse_entry_out, fuse_attr_out, fuse_open_out};
 use native::{fuse_write_out, fuse_statfs_out, fuse_getxattr_out, fuse_lk_out};
 use native::{fuse_init_out, fuse_bmap_out, fuse_out_header, fuse_dirent};
+#[cfg(target_os = "macos")]
+use native::{fuse_getxtimes_out};
 
 /// Trait for types that can be sent as a reply to the FUSE kernel driver
 pub trait Sendable {
@@ -26,7 +28,6 @@ pub trait Sendable {
 // Implemente sendable trait for fuse_*_out data types
 impl Sendable for fuse_entry_out { }
 impl Sendable for fuse_attr_out { }
-impl Sendable for fuse_getxtimes_out { }
 impl Sendable for fuse_open_out { }
 impl Sendable for fuse_write_out { }
 impl Sendable for fuse_statfs_out { }
@@ -35,6 +36,8 @@ impl Sendable for fuse_lk_out { }
 impl Sendable for fuse_init_out { }
 impl Sendable for fuse_bmap_out { }
 impl Sendable for fuse_out_header { }
+#[cfg(target_os = "macos")]
+impl Sendable for fuse_getxtimes_out { }
 
 impl<S: Sendable> Sendable for ~S {
 	fn as_bytegroups<T> (&self, f: &fn(&[&[u8]]) -> T) -> T {


### PR DESCRIPTION
This adds an impl of `Default` to `fuse_attr` to avoid having to have OS-specific code in the examples.  Everything else is pretty straightforward.
