### PR TITLE
On OS X only, use libc unmount directly

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -33,6 +33,7 @@ pub struct fuse_args {
 
 extern "system" {
 	pub fn fuse_mount_compat25 (mountpoint: *c_char, args: *fuse_args) -> c_int;
+	#[cfg(not(target_os = "macos"))]
 	pub fn fuse_unmount_compat22 (mountpoint: *c_char);
 }
 


### PR DESCRIPTION
On OS X, fuse_unmount_compat22 calls realpath, which calls back into the
file system.  If an error is returned from this operation, it then
proceeds to silently do nothing.  This can cause a background filesystem
to stay mounted and hang rather than unmounting when a BackgroundSession
is destroyed.

So instead, we get the realpath at mount time, and then at unmount just
call unmount directly.

This only applies to OS X.  On other platforms, fuse_unmount_compat22 is
more complex, and still needs to be used.

Fixes #7.
