### PR TITLE
fixed problems with imports in libc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@ extern crate log;
 extern crate time;
 
 use std::io::{FileType, FilePermission};
-use libc::{c_int, ENOSYS};
+use libc::c_int;
+use libc::consts::os::posix88::ENOSYS;
 use time::Timespec;
 
 pub use fuse::FUSE_ROOT_ID;

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -10,7 +10,8 @@
 
 use std::{cast, mem, ptr, slice};
 use std::io::{FileType, TypeFile, TypeDirectory, TypeNamedPipe, TypeBlockSpecial, TypeSymlink, TypeUnknown, FilePermission};
-use libc::{c_int, EIO};
+use libc::c_int;
+use libc::consts::os::posix88::EIO;
 use libc::{S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK};
 use time::Timespec;
 use fuse::{fuse_attr, fuse_kstatfs, fuse_file_lock, fuse_entry_out, fuse_attr_out};

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,7 +4,7 @@
 //!
 
 use std::{mem, str};
-use libc::{EIO, ENOSYS, EPROTO};
+use libc::consts::os::posix88::{EIO, ENOSYS, EPROTO};
 use time::Timespec;
 use argument::ArgumentIterator;
 use channel::ChannelSender;


### PR DESCRIPTION
Since rust version https://github.com/mozilla/rust/commit/bfaf171c6dff38faecf4de29abcedc6a128c4cec, some libc exports are no longer exported. Make can't build the lib.

I re-imported them using full path.
