### PR TITLE
Fix for nightly

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -68,9 +68,9 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn read (&mut self, _req: &Request, ino: u64, _fh: u64, offset: u64, _size: uint, reply: ReplyData) {
+    fn read (&mut self, _req: &Request, ino: u64, _fh: u64, offset: u64, _size: usize, reply: ReplyData) {
         if ino == 2 {
-            reply.data(HELLO_TXT_CONTENT.as_bytes().slice_from(offset as uint));
+            reply.data(HELLO_TXT_CONTENT.as_bytes().slice_from(offset as usize));
         } else {
             reply.error(ENOENT);
         }

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -9,7 +9,7 @@ use std::path::PosixPath;
 /// An iterator that can be used to fetch typed arguments from a byte slice
 pub struct ArgumentIterator<'a> {
     data: &'a [u8],
-    pos: uint,
+    pos: usize,
 }
 
 impl<'a> ArgumentIterator<'a> {
@@ -20,7 +20,7 @@ impl<'a> ArgumentIterator<'a> {
 
     /// Fetch a typed argument
     pub fn fetch<T> (&mut self) -> &'a T {
-        let value = unsafe { mem::transmute(self.data.as_ptr().offset(self.pos as int)) };
+        let value = unsafe { mem::transmute(self.data.as_ptr().offset(self.pos as isize)) };
         self.pos += mem::size_of::<T>();
         assert!(self.pos <= self.data.len(), "trying to fetch argument behind data");
         value

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -32,14 +32,14 @@ mod libc {
     }
 
     /// Max length for path names. 4096 should be reasonable safe (OS X uses 1024, Linux uses 4096)
-    pub const PATH_MAX: int = 4096;
+    pub const PATH_MAX: isize = 4096;
 }
 
 /// Wrapper around libc's realpath.  Returns the errno value if the real path cannot be obtained.
 /// FIXME: Use Rust's realpath method once available in std (see also https://github.com/mozilla/rust/issues/11857)
 fn real_path (path: &PosixPath) -> Result<PosixPath, c_int> {
     let cpath = CString::from_slice(path.as_vec());
-    let mut resolved = [0; libc::PATH_MAX as uint];
+    let mut resolved = [0; libc::PATH_MAX as usize];
     unsafe {
         if libc::realpath(cpath.as_ptr(), resolved.as_mut_ptr()).is_null() {
             Err(os::errno() as c_int)
@@ -90,12 +90,12 @@ impl Channel {
 
     /// Receives data up to the size of the given buffer (can block) and returns
     /// the size of the received data.
-    pub fn receive (&self, buffer: &mut [u8]) -> Result<uint, c_int> {
+    pub fn receive (&self, buffer: &mut [u8]) -> Result<usize, c_int> {
         let rc = unsafe { ::libc::read(self.fd, buffer.as_ptr() as *mut c_void, buffer.len() as size_t) };
         if rc < 0 {
             Err(os::errno() as c_int)
         } else {
-            Ok(rc as uint)
+            Ok(rc as usize)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub trait Filesystem {
     /// each forget. The filesystem may ignore forget calls, if the inodes don't need to
     /// have a limited lifetime. On unmount it is not guaranteed, that all referenced
     /// inodes will receive a forget message.
-    fn forget (&mut self, _req: &Request, _ino: u64, _nlookup: uint) {
+    fn forget (&mut self, _req: &Request, _ino: u64, _nlookup: usize) {
     }
 
     /// Get file attributes
@@ -162,7 +162,7 @@ pub trait Filesystem {
     /// anything in fh. There are also some flags (direct_io, keep_cache) which the
     /// filesystem may set, to change the way the file is opened. See fuse_file_info
     /// structure in <fuse_common.h> for more details.
-    fn open (&mut self, _req: &Request, _ino: u64, _flags: uint, reply: ReplyOpen) {
+    fn open (&mut self, _req: &Request, _ino: u64, _flags: usize, reply: ReplyOpen) {
         reply.opened(0, 0);
     }
 
@@ -173,7 +173,7 @@ pub trait Filesystem {
     /// return value of the read system call will reflect the return value of this
     /// operation. fh will contain the value set by the open method, or will be undefined
     /// if the open method didn't set any value.
-    fn read (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, _size: uint, reply: ReplyData) {
+    fn read (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, _size: usize, reply: ReplyData) {
         reply.error(ENOSYS);
     }
 
@@ -183,7 +183,7 @@ pub trait Filesystem {
     /// which case the return value of the write system call will reflect the return
     /// value of this operation. fh will contain the value set by the open method, or
     /// will be undefined if the open method didn't set any value.
-    fn write (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, _data: &[u8], _flags: uint, reply: ReplyWrite) {
+    fn write (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, _data: &[u8], _flags: usize, reply: ReplyWrite) {
         reply.error(ENOSYS);
     }
 
@@ -209,7 +209,7 @@ pub trait Filesystem {
     /// the release. fh will contain the value set by the open method, or will be undefined
     /// if the open method didn't set any value. flags will contain the same flags as for
     /// open.
-    fn release (&mut self, _req: &Request, _ino: u64, _fh: u64, _flags: uint, _lock_owner: u64, _flush: bool, reply: ReplyEmpty) {
+    fn release (&mut self, _req: &Request, _ino: u64, _fh: u64, _flags: usize, _lock_owner: u64, _flush: bool, reply: ReplyEmpty) {
         reply.ok();
     }
 
@@ -227,7 +227,7 @@ pub trait Filesystem {
     /// anything in fh, though that makes it impossible to implement standard conforming
     /// directory stream operations in case the contents of the directory can change
     /// between opendir and releasedir.
-    fn opendir (&mut self, _req: &Request, _ino: u64, _flags: uint, reply: ReplyOpen) {
+    fn opendir (&mut self, _req: &Request, _ino: u64, _flags: usize, reply: ReplyOpen) {
         reply.opened(0, 0);
     }
 
@@ -244,7 +244,7 @@ pub trait Filesystem {
     /// For every opendir call there will be exactly one releasedir call. fh will
     /// contain the value set by the opendir method, or will be undefined if the
     /// opendir method didn't set any value.
-    fn releasedir (&mut self, _req: &Request, _ino: u64, _fh: u64, _flags: uint, reply: ReplyEmpty) {
+    fn releasedir (&mut self, _req: &Request, _ino: u64, _fh: u64, _flags: usize, reply: ReplyEmpty) {
         reply.ok();
     }
 
@@ -262,7 +262,7 @@ pub trait Filesystem {
     }
 
     /// Set an extended attribute
-    fn setxattr (&mut self, _req: &Request, _ino: u64, _name: &[u8], _value: &[u8], _flags: uint, _position: u32, reply: ReplyEmpty) {
+    fn setxattr (&mut self, _req: &Request, _ino: u64, _name: &[u8], _value: &[u8], _flags: usize, _position: u32, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
@@ -289,7 +289,7 @@ pub trait Filesystem {
     /// This will be called for the access() system call. If the 'default_permissions'
     /// mount option is given, this method is not called. This method is not called
     /// under Linux kernel versions 2.4.x
-    fn access (&mut self, _req: &Request, _ino: u64, _mask: uint, reply: ReplyEmpty) {
+    fn access (&mut self, _req: &Request, _ino: u64, _mask: usize, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
@@ -303,7 +303,7 @@ pub trait Filesystem {
     /// structure in <fuse_common.h> for more details. If this method is not
     /// implemented or under Linux kernel versions earlier than 2.6.15, the mknod()
     /// and open() methods will be called instead.
-    fn create (&mut self, _req: &Request, _parent: u64, _name: &PosixPath, _mode: u32, _flags: uint, reply: ReplyCreate) {
+    fn create (&mut self, _req: &Request, _parent: u64, _name: &PosixPath, _mode: u32, _flags: usize, reply: ReplyCreate) {
         reply.error(ENOSYS);
     }
 
@@ -326,7 +326,7 @@ pub trait Filesystem {
     /// Map block index within file to block index within device
     /// Note: This makes sense only for block device backed filesystems mounted
     /// with the 'blkdev' option
-    fn bmap (&mut self, _req: &Request, _ino: u64, _blocksize: uint, _idx: u64, reply: ReplyBmap) {
+    fn bmap (&mut self, _req: &Request, _ino: u64, _blocksize: usize, _idx: u64, reply: ReplyBmap) {
         reply.error(ENOSYS);
     }
 
@@ -339,7 +339,7 @@ pub trait Filesystem {
 
     /// OS X only (undocumented)
     #[cfg(target_os = "macos")]
-    fn exchange (&mut self, _req: &Request, _parent: u64, _name: &PosixPath, _newparent: u64, _newname: &PosixPath, _options: uint, reply: ReplyEmpty) {
+    fn exchange (&mut self, _req: &Request, _parent: u64, _name: &PosixPath, _newparent: u64, _newname: &PosixPath, _options: usize, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,6 @@ pub fn mount<FS: Filesystem+Send> (filesystem: FS, mountpoint: &Path, options: &
 /// and therefore returns immediately. The returned handle should be stored
 /// to reference the mounted filesystem. If it's dropped, the filesystem will
 /// be unmounted.
-pub fn spawn_mount<FS: Filesystem+Send> (filesystem: FS, mountpoint: &Path, options: &[&[u8]]) -> BackgroundSession {
+pub fn spawn_mount<'a, FS: Filesystem+Send> (filesystem: FS, mountpoint: &Path, options: &[&[u8]]) -> BackgroundSession<'a> {
     Session::new(filesystem, mountpoint, options).spawn()
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -503,7 +503,7 @@ impl ReplyBmap {
 ///
 pub struct ReplyDirectory {
     reply: ReplyRaw<()>,
-    size: uint,
+    size: usize,
     data: Vec<u8>,
 }
 
@@ -515,7 +515,7 @@ impl Reply for ReplyDirectory {
 
 impl ReplyDirectory {
     /// Changes the max size of the directory buffer
-    pub fn sized (mut self, size: uint) -> ReplyDirectory {
+    pub fn sized (mut self, size: usize) -> ReplyDirectory {
         self.size = size;
         self.data.reserve(size);
         self
@@ -531,15 +531,15 @@ impl ReplyDirectory {
         let padlen = entsize - entlen;
         if self.data.len() + entsize > self.data.capacity() { return true; }
         unsafe {
-            let p = self.data.as_mut_ptr().offset(self.data.len() as int);
+            let p = self.data.as_mut_ptr().offset(self.data.len() as isize);
             let pdirent: *mut fuse_dirent = mem::transmute(p);
             (*pdirent).ino = ino;
             (*pdirent).off = offset;
             (*pdirent).namelen = name.len() as u32;
             (*pdirent).typ = mode_from_kind_and_perm(kind, FilePermission::empty()) >> 12;
-            let p = p.offset(mem::size_of_val(&*pdirent) as int);
+            let p = p.offset(mem::size_of_val(&*pdirent) as isize);
             ptr::copy_memory(p, name.as_ptr(), name.len());
-            let p = p.offset(name.len() as int);
+            let p = p.offset(name.len() as isize);
             ptr::zero_memory(p, padlen);
             let newlen = self.data.len() + entsize;
             self.data.set_len(newlen);

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -114,7 +114,7 @@ pub struct ReplyRaw<T> {
 
 impl<T> Reply for ReplyRaw<T> {
     fn new<F: FnOnce(&[&[u8]])+Send> (unique: u64, sender: F) -> ReplyRaw<T> {
-        let sender: Box<for<'a> Invoke<&'a [&'a [u8]]> + Send> = box sender;
+        let sender: Box<for<'a> Invoke<&'a [&'a [u8]]> + Send> = Box::new(sender);
         ReplyRaw { unique: unique, sender: Some(sender) }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -60,7 +60,7 @@ impl<'a> Request<'a> {
             header: data.fetch(),
             data: data.fetch_data(),
         };
-        if buffer.len() < req.header.len as uint {
+        if buffer.len() < req.header.len as usize {
             error!("Short read of FUSE request ({} < {})", buffer.len(), req.header.len);
             return None;
         }
@@ -93,8 +93,8 @@ impl<'a> Request<'a> {
                     return;
                 }
                 // Remember ABI version supported by kernel
-                se.proto_major = arg.major as uint;
-                se.proto_minor = arg.minor as uint;
+                se.proto_major = arg.major as usize;
+                se.proto_minor = arg.minor as usize;
                 // Call filesystem init method and give it a chance to return an error
                 let res = se.filesystem.init(self);
                 if res.is_err() {
@@ -149,7 +149,7 @@ impl<'a> Request<'a> {
             FUSE_FORGET => {
                 let arg: &fuse_forget_in = data.fetch();
                 debug!("FORGET({}) ino {:#018x}, nlookup {}", self.header.unique, self.header.nodeid, arg.nlookup);
-                se.filesystem.forget(self, self.header.nodeid, arg.nlookup as uint);    // no reply
+                se.filesystem.forget(self, self.header.nodeid, arg.nlookup as usize);    // no reply
             },
             FUSE_GETATTR => {
                 debug!("GETATTR({}) ino {:#018x}", self.header.unique, self.header.nodeid);
@@ -228,19 +228,19 @@ impl<'a> Request<'a> {
             FUSE_OPEN => {
                 let arg: &fuse_open_in = data.fetch();
                 debug!("OPEN({}) ino {:#018x}, flags {:#x}", self.header.unique, self.header.nodeid, arg.flags);
-                se.filesystem.open(self, self.header.nodeid, arg.flags as uint, self.reply());
+                se.filesystem.open(self, self.header.nodeid, arg.flags as usize, self.reply());
             },
             FUSE_READ => {
                 let arg: &fuse_read_in = data.fetch();
                 debug!("READ({}) ino {:#018x}, fh {}, offset {}, size {}", self.header.unique, self.header.nodeid, arg.fh, arg.offset, arg.size);
-                se.filesystem.read(self, self.header.nodeid, arg.fh, arg.offset, arg.size as uint, self.reply());
+                se.filesystem.read(self, self.header.nodeid, arg.fh, arg.offset, arg.size as usize, self.reply());
             },
             FUSE_WRITE => {
                 let arg: &fuse_write_in = data.fetch();
                 let data = data.fetch_data();
-                assert!(data.len() == arg.size as uint);
+                assert!(data.len() == arg.size as usize);
                 debug!("WRITE({}) ino {:#018x}, fh {}, offset {}, size {}, flags {:#x}", self.header.unique, self.header.nodeid, arg.fh, arg.offset, arg.size, arg.write_flags);
-                se.filesystem.write(self, self.header.nodeid, arg.fh, arg.offset, data, arg.write_flags as uint, self.reply());
+                se.filesystem.write(self, self.header.nodeid, arg.fh, arg.offset, data, arg.write_flags as usize, self.reply());
             },
             FUSE_FLUSH => {
                 let arg: &fuse_flush_in = data.fetch();
@@ -251,7 +251,7 @@ impl<'a> Request<'a> {
                 let arg: &fuse_release_in = data.fetch();
                 let flush = match arg.release_flags & FUSE_RELEASE_FLUSH { 0 => false, _ => true };
                 debug!("RELEASE({}) ino {:#018x}, fh {}, flags {:#x}, release flags {:#x}, lock owner {}", self.header.unique, self.header.nodeid, arg.fh, arg.flags, arg.release_flags, arg.lock_owner);
-                se.filesystem.release(self, self.header.nodeid, arg.fh, arg.flags as uint, arg.lock_owner, flush, self.reply());
+                se.filesystem.release(self, self.header.nodeid, arg.fh, arg.flags as usize, arg.lock_owner, flush, self.reply());
             },
             FUSE_FSYNC => {
                 let arg: &fuse_fsync_in = data.fetch();
@@ -262,17 +262,17 @@ impl<'a> Request<'a> {
             FUSE_OPENDIR => {
                 let arg: &fuse_open_in = data.fetch();
                 debug!("OPENDIR({}) ino {:#018x}, flags {:#x}", self.header.unique, self.header.nodeid, arg.flags);
-                se.filesystem.opendir(self, self.header.nodeid, arg.flags as uint, self.reply());
+                se.filesystem.opendir(self, self.header.nodeid, arg.flags as usize, self.reply());
             },
             FUSE_READDIR => {
                 let arg: &fuse_read_in = data.fetch();
                 debug!("READDIR({}) ino {:#018x}, fh {}, offset {}, size {}", self.header.unique, self.header.nodeid, arg.fh, arg.offset, arg.size);
-                se.filesystem.readdir(self, self.header.nodeid, arg.fh, arg.offset, self.reply::<ReplyDirectory>().sized(arg.size as uint));
+                se.filesystem.readdir(self, self.header.nodeid, arg.fh, arg.offset, self.reply::<ReplyDirectory>().sized(arg.size as usize));
             },
             FUSE_RELEASEDIR => {
                 let arg: &fuse_release_in = data.fetch();
                 debug!("RELEASEDIR({}) ino {:#018x}, fh {}, flags {:#x}, release flags {:#x}, lock owner {}", self.header.unique, self.header.nodeid, arg.fh, arg.flags, arg.release_flags, arg.lock_owner);
-                se.filesystem.releasedir(self, self.header.nodeid, arg.fh, arg.flags as uint, self.reply());
+                se.filesystem.releasedir(self, self.header.nodeid, arg.fh, arg.flags as usize, self.reply());
             },
             FUSE_FSYNCDIR => {
                 let arg: &fuse_fsync_in = data.fetch();
@@ -288,13 +288,13 @@ impl<'a> Request<'a> {
                 let arg: &fuse_setxattr_in = data.fetch();
                 let name = data.fetch_str();
                 let value = data.fetch_data();
-                assert!(value.len() == arg.size as uint);
+                assert!(value.len() == arg.size as usize);
                 debug!("SETXATTR({}) ino {:#018x}, name {}, size {}, flags {:#x}", self.header.unique, self.header.nodeid, String::from_utf8_lossy(name), arg.size, arg.flags);
                 #[cfg(target_os = "macos")] #[inline]
                 fn get_position (arg: &fuse_setxattr_in) -> u32 { arg.position }
                 #[cfg(not(target_os = "macos"))] #[inline]
                 fn get_position (_arg: &fuse_setxattr_in) -> u32 { 0 }
-                se.filesystem.setxattr(self, self.header.nodeid, name, value, arg.flags as uint, get_position(arg), self.reply());
+                se.filesystem.setxattr(self, self.header.nodeid, name, value, arg.flags as usize, get_position(arg), self.reply());
             },
             FUSE_GETXATTR => {
                 let arg: &fuse_getxattr_in = data.fetch();
@@ -315,13 +315,13 @@ impl<'a> Request<'a> {
             FUSE_ACCESS => {
                 let arg: &fuse_access_in = data.fetch();
                 debug!("ACCESS({}) ino {:#018x}, mask {:#05o}", self.header.unique, self.header.nodeid, arg.mask);
-                se.filesystem.access(self, self.header.nodeid, arg.mask as uint, self.reply());
+                se.filesystem.access(self, self.header.nodeid, arg.mask as usize, self.reply());
             },
             FUSE_CREATE => {
                 let arg: &fuse_open_in = data.fetch();
                 let name = data.fetch_path();
                 debug!("CREATE({}) parent {:#018x}, name {}, mode {:#05o}, flags {:#x}", self.header.unique, self.header.nodeid, name.display(), arg.mode, arg.flags);
-                se.filesystem.create(self, self.header.nodeid, &name, arg.mode, arg.flags as uint, self.reply());
+                se.filesystem.create(self, self.header.nodeid, &name, arg.mode, arg.flags as usize, self.reply());
             },
             FUSE_GETLK => {
                 let arg: &fuse_lk_in = data.fetch();
@@ -337,7 +337,7 @@ impl<'a> Request<'a> {
             FUSE_BMAP => {
                 let arg: &fuse_bmap_in = data.fetch();
                 debug!("BMAP({}) ino {:#018x}, blocksize {}, ids {}", self.header.unique, self.header.nodeid, arg.blocksize, arg.block);
-                se.filesystem.bmap(self, self.header.nodeid, arg.blocksize as uint, arg.block, self.reply());
+                se.filesystem.bmap(self, self.header.nodeid, arg.blocksize as usize, arg.block, self.reply());
             },
             #[cfg(target_os = "macos")]
             FUSE_SETVOLNAME => {                        // OS X only
@@ -351,7 +351,7 @@ impl<'a> Request<'a> {
                 let oldname = data.fetch_path();
                 let newname = data.fetch_path();
                 debug!("EXCHANGE({}) parent {:#018x}, name {}, newparent {:#018x}, newname {}, options {:#x}", self.header.unique, arg.olddir, oldname.display(), arg.newdir, newname.display(), arg.options);
-                se.filesystem.exchange(self, arg.olddir, &oldname, arg.newdir, &newname, arg.options as uint, self.reply());
+                se.filesystem.exchange(self, arg.olddir, &oldname, arg.newdir, &newname, arg.options as usize, self.reply());
             },
             #[cfg(target_os = "macos")]
             FUSE_GETXTIMES => {                         // OS X only

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,11 +17,11 @@ use request::{request, dispatch};
 /// The max size of write requests from the kernel. The absolute minimum is 4k,
 /// FUSE recommends at least 128k, max 16M. The FUSE default is 16M on OS X
 /// and 128k on other systems.
-pub const MAX_WRITE_SIZE: uint = 16*1024*1024;
+pub const MAX_WRITE_SIZE: usize = 16*1024*1024;
 
 /// Size of the buffer for reading a request from the kernel. Since the kernel may send
 /// up to MAX_WRITE_SIZE bytes in a write request, we use that value plus some extra space.
-const BUFFER_SIZE: uint = MAX_WRITE_SIZE + 4096;
+const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
 
 /// The session data structure
 pub struct Session<FS> {
@@ -32,9 +32,9 @@ pub struct Session<FS> {
     /// Communication channel to the kernel driver
     ch: Channel,
     /// FUSE protocol major version
-    pub proto_major: uint,
+    pub proto_major: usize,
     /// FUSE protocol minor version
-    pub proto_minor: uint,
+    pub proto_minor: usize,
     /// True if the filesystem is initialized (init operation done)
     pub initialized: bool,
     /// True if the filesystem was destroyed (destroy operation done)


### PR DESCRIPTION
I fixed some error and warnings for compliance with rust nightly.
* replace int/uint with isize/usize
* use  Box::new
* specify lifetime parameter for JoinGuard.

All tests are passed and my rust version is `rustc 1.0.0-nightly (44a287e6e 2015-01-08 17:03:40 -0800)`