### PR TITLE
Configure Travis CI to build on Linux as well as on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libfuse-dev; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install osxfuse; fi
+before_script:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DYLD_LIBRARY_PATH="$HOME/rust/lib"; fi
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
+os:
+  - linux
+  - osx
 language: rust
 env:
   global:
     - secure: atCJyliV0MQp8aNBrDc1iymeAxNJWFZPU0OmyhK94+/1FjU1pw7MU3cdSCN1dHY82/4bmKGsewRwCnpj5SPYPG2BbOSAuKobLvGO/mlagqFrdnJtmCmsGda0F2wZ3PNC30zfx0L+TsngB34URcgWGCfzPvyDS0JuHTIwl25YiX8=
 before_install:
-  - sudo apt-get update
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
 install:
-  - sudo apt-get install libfuse-dev
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libfuse-dev; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install osxfuse; fi
 script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc --verbose
 after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  mv target/doc . &&
-  (curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh)
+  if [ "$TRAVIS_BRANCH" = "master" ]; then
+    mv target/doc . &&
+    (curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh)
+  fi


### PR DESCRIPTION
Since Travis CI enabled OS X workers for this project, we can now test builds on Linux and OS X.

Unfortunately rustc doesn't seem to work on Travis OS X right now.
