### PR TITLE
Updated order of arguments for copy_nonoverlapping.

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -541,7 +541,7 @@ impl ReplyDirectory {
             (*pdirent).namelen = name.len() as u32;
             (*pdirent).typ = mode_from_kind_and_perm(kind, 0) >> 12;
             let p = p.offset(mem::size_of_val(&*pdirent) as isize);
-            ptr::copy_nonoverlapping(p, name.as_ptr(), name.len());
+            ptr::copy_nonoverlapping(name.as_ptr(), p, name.len());
             let p = p.offset(name.len() as isize);
             ptr::write_bytes(p, 0u8, padlen);
             let newlen = self.data.len() + entsize;


### PR DESCRIPTION
See rust-lang/rust@acd48a2b3e7fcc0372f7718a2fac1cf80e03db95 for details.