### PR TITLE
Update for latest nightly

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -117,7 +117,7 @@ pub struct BackgroundSession<'a> {
     /// Path of the mounted filesystem
     pub mountpoint: PathBuf,
     /// Thread guard of the background session
-    pub guard: JoinGuard<'a ()>,
+    pub guard: JoinGuard<'a, ()>,
 }
 
 impl<'a> BackgroundSession<'a> {


### PR DESCRIPTION
Rust now enforces a comma between lifetime and type, see
https://github.com/rust-lang/rust/pull/24547 for the change.