### PR TITLE
derive or implement fmt::Debug for public types

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -67,6 +67,7 @@ fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T> (options: &[&OsStr], f: F) -> T
 }
 
 /// A raw communication channel to the FUSE kernel driver
+#[derive(Debug)]
 pub struct Channel {
     mountpoint: PathBuf,
     fd: c_int,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -131,7 +131,7 @@ impl Drop for Channel {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ChannelSender {
     fd: c_int,
 }

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -11,6 +11,7 @@ use libc::{c_int, c_char};
 //
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_args {
     pub argc: c_int,
     pub argv: *const *const c_char,
@@ -35,6 +36,7 @@ pub const FUSE_KERNEL_MINOR_VERSION: u32 = 8;
 pub const FUSE_ROOT_ID: u64 = 1;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_attr {
     pub ino: u64,
     pub size: u64,
@@ -59,6 +61,7 @@ pub struct fuse_attr {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_kstatfs {
     pub blocks: u64,            // Total blocks (in units of frsize)
     pub bfree: u64,             // Free blocks
@@ -73,6 +76,7 @@ pub struct fuse_kstatfs {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_file_lock {
     pub start: u64,
     pub end: u64,
@@ -126,6 +130,7 @@ pub mod consts {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub enum fuse_opcode {
     FUSE_LOOKUP = 1,
     FUSE_FORGET = 2,            // no reply
@@ -223,6 +228,7 @@ impl fuse_opcode {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_entry_out {
     pub nodeid: u64,
     pub generation: u64,
@@ -234,11 +240,13 @@ pub struct fuse_entry_out {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_forget_in {
     pub nlookup: u64,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_attr_out {
     pub attr_valid: i64,
     pub attr_valid_nsec: i32,
@@ -248,6 +256,7 @@ pub struct fuse_attr_out {
 
 #[cfg(target_os = "macos")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_getxtimes_out { // OS X only
     pub bkuptime: i64,
     pub crtime: i64,
@@ -256,24 +265,28 @@ pub struct fuse_getxtimes_out { // OS X only
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_mknod_in {
     pub mode: u32,
     pub rdev: u32,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_mkdir_in {
     pub mode: u32,
     pub padding: u32,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_rename_in {
     pub newdir: u64,
 }
 
 #[cfg(target_os = "macos")]
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_exchange_in {   // OS X only
     pub olddir: u64,
     pub newdir: u64,
@@ -281,11 +294,13 @@ pub struct fuse_exchange_in {   // OS X only
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_link_in {
     pub oldnodeid: u64,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_setattr_in {
     pub valid: u32,
     pub padding: u32,
@@ -320,12 +335,14 @@ pub struct fuse_setattr_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_open_in {
     pub flags: u32,
     pub mode: u32,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_open_out {
     pub fh: u64,
     pub open_flags: u32,
@@ -333,6 +350,7 @@ pub struct fuse_open_out {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_release_in {
     pub fh: u64,
     pub flags: u32,
@@ -341,6 +359,7 @@ pub struct fuse_release_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_flush_in {
     pub fh: u64,
     pub unused: u32,
@@ -349,6 +368,7 @@ pub struct fuse_flush_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_read_in {
     pub fh: u64,
     pub offset: u64,
@@ -357,6 +377,7 @@ pub struct fuse_read_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_write_in {
     pub fh: u64,
     pub offset: u64,
@@ -365,17 +386,20 @@ pub struct fuse_write_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_write_out {
     pub size: u32,
     pub padding: u32,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_statfs_out {
     pub st: fuse_kstatfs,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_fsync_in {
     pub fh: u64,
     pub fsync_flags: u32,
@@ -383,6 +407,7 @@ pub struct fuse_fsync_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_setxattr_in {
     pub size: u32,
     pub flags: u32,
@@ -393,6 +418,7 @@ pub struct fuse_setxattr_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_getxattr_in {
     pub size: u32,
     pub padding: u32,
@@ -403,12 +429,14 @@ pub struct fuse_getxattr_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_getxattr_out {
     pub size: u32,
     pub padding: u32,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_lk_in {
     pub fh: u64,
     pub owner: u64,
@@ -416,17 +444,20 @@ pub struct fuse_lk_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_lk_out {
     pub lk: fuse_file_lock,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_access_in {
     pub mask: u32,
     pub padding: u32,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_init_in {
     pub major: u32,
     pub minor: u32,
@@ -435,6 +466,7 @@ pub struct fuse_init_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_init_out {
     pub major: u32,
     pub minor: u32,
@@ -445,11 +477,13 @@ pub struct fuse_init_out {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_interrupt_in {
     pub unique: u64,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_bmap_in {
     pub block: u64,
     pub blocksize: u32,
@@ -457,6 +491,7 @@ pub struct fuse_bmap_in {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_bmap_out {
     pub block: u64,
 }
@@ -475,6 +510,7 @@ pub struct fuse_in_header {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_out_header {
     pub len: u32,
     pub error: i32,
@@ -482,6 +518,7 @@ pub struct fuse_out_header {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_dirent {
     pub ino: u64,
     pub off: u64,

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -462,6 +462,7 @@ pub struct fuse_bmap_out {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct fuse_in_header {
     pub len: u32,
     pub opcode: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![doc(html_root_url = "https://zargony.github.io/rust-fuse")]
 
-#![warn(missing_docs, bad_style, unused, unused_extern_crates, unused_import_braces, unused_qualifications)]
+#![warn(missing_docs, bad_style, unused, unused_extern_crates, unused_import_braces, unused_qualifications, missing_debug_implementations)]
 
 extern crate libc;
 #[macro_use]

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -11,6 +11,7 @@
 use std::{mem, ptr, slice};
 use std::convert::AsRef;
 use std::ffi::OsStr;
+use std::fmt;
 use std::marker::PhantomData;
 use std::os::unix::ffi::OsStrExt;
 use libc::{c_int, S_IFIFO, S_IFCHR, S_IFBLK, S_IFDIR, S_IFREG, S_IFLNK};
@@ -27,6 +28,12 @@ use {FileType, FileAttr};
 pub trait ReplySender: Send + 'static {
     /// Send data.
     fn send(&self, data: &[&[u8]]);
+}
+
+impl fmt::Debug for Box<ReplySender> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "Box<ReplySender>")
+    }
 }
 
 /// Generic reply trait
@@ -111,6 +118,7 @@ fn fuse_attr_from_attr (attr: &FileAttr) -> fuse_attr {
 ///
 /// Raw reply
 ///
+#[derive(Debug)]
 pub struct ReplyRaw<T> {
     /// Unique id of the request to reply to
     unique: u64,
@@ -172,6 +180,7 @@ impl<T> Drop for ReplyRaw<T> {
 ///
 /// Empty reply
 ///
+#[derive(Debug)]
 pub struct ReplyEmpty {
     reply: ReplyRaw<()>,
 }
@@ -197,6 +206,7 @@ impl ReplyEmpty {
 ///
 /// Data reply
 ///
+#[derive(Debug)]
 pub struct ReplyData {
     reply: ReplyRaw<()>,
 }
@@ -222,6 +232,7 @@ impl ReplyData {
 ///
 /// Entry reply
 ///
+#[derive(Debug)]
 pub struct ReplyEntry {
     reply: ReplyRaw<fuse_entry_out>,
 }
@@ -255,6 +266,7 @@ impl ReplyEntry {
 ///
 /// Attribute Reply
 ///
+#[derive(Debug)]
 pub struct ReplyAttr {
     reply: ReplyRaw<fuse_attr_out>,
 }
@@ -286,6 +298,7 @@ impl ReplyAttr {
 /// XTimes Reply
 ///
 #[cfg(target_os = "macos")]
+#[derive(Debug)]
 pub struct ReplyXTimes {
     reply: ReplyRaw<fuse_getxtimes_out>,
 }
@@ -318,6 +331,7 @@ impl ReplyXTimes {
 ///
 /// Open Reply
 ///
+#[derive(Debug)]
 pub struct ReplyOpen {
     reply: ReplyRaw<fuse_open_out>,
 }
@@ -347,6 +361,7 @@ impl ReplyOpen {
 ///
 /// Write Reply
 ///
+#[derive(Debug)]
 pub struct ReplyWrite {
     reply: ReplyRaw<fuse_write_out>,
 }
@@ -375,6 +390,7 @@ impl ReplyWrite {
 ///
 /// Statfs Reply
 ///
+#[derive(Debug)]
 pub struct ReplyStatfs {
     reply: ReplyRaw<fuse_statfs_out>,
 }
@@ -413,6 +429,7 @@ impl ReplyStatfs {
 ///
 /// Create reply
 ///
+#[derive(Debug)]
 pub struct ReplyCreate {
     reply: ReplyRaw<(fuse_entry_out, fuse_open_out)>,
 }
@@ -450,6 +467,7 @@ impl ReplyCreate {
 ///
 /// Lock Reply
 ///
+#[derive(Debug)]
 pub struct ReplyLock {
     reply: ReplyRaw<fuse_lk_out>,
 }
@@ -482,6 +500,7 @@ impl ReplyLock {
 ///
 /// Bmap Reply
 ///
+#[derive(Debug)]
 pub struct ReplyBmap {
     reply: ReplyRaw<fuse_bmap_out>,
 }
@@ -509,6 +528,7 @@ impl ReplyBmap {
 ///
 /// Directory reply
 ///
+#[derive(Debug)]
 pub struct ReplyDirectory {
     reply: ReplyRaw<()>,
     size: usize,

--- a/src/request.rs
+++ b/src/request.rs
@@ -35,6 +35,7 @@ pub fn dispatch<FS: Filesystem> (req: &Request, se: &mut Session<FS>) {
 }
 
 /// Request data structure
+#[derive(Debug)]
 pub struct Request<'a> {
     /// Channel sender for sending the reply
     ch: ChannelSender,

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,6 +8,7 @@
 
 use std::io;
 use std::ffi::OsStr;
+use std::fmt;
 use std::path::{PathBuf, Path};
 use thread_scoped::{scoped, JoinGuard};
 use libc::{EAGAIN, EINTR, ENODEV, ENOENT};
@@ -26,6 +27,7 @@ pub const MAX_WRITE_SIZE: usize = 16*1024*1024;
 const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
 
 /// The session data structure
+#[derive(Debug)]
 pub struct Session<FS: Filesystem> {
     /// Filesystem operation implementations
     pub filesystem: FS,
@@ -143,5 +145,13 @@ impl<'a> Drop for BackgroundSession<'a> {
             Ok(()) => (),
             Err(err) => error!("Failed to unmount {}: {}", self.mountpoint.display(), err),
         }
+    }
+}
+
+// replace with #[derive(Debug)] if Debug ever gets implemented for
+// thread_scoped::JoinGuard
+impl<'a> fmt::Debug for BackgroundSession<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "BackgroundSession {{ mountpoint: {:?}, guard: JoinGuard<()> }}", self.mountpoint)
     }
 }


### PR DESCRIPTION
@zargony thanks for this library!

I was slightly surprised to find that I couldn't print out a request with `"{:?}"`, inspiring this pull request that adds `Debug` derivations (and turns on the `missing_debug_implementations` lint), as recommended in the [`std::fmt` documentation](https://doc.rust-lang.org/std/fmt/#fmtdisplay-vs-fmtdebug).
