### PR TITLE
Remove ReplyDirectory::sized().

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -866,7 +866,7 @@ mod test {
                      0x08, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,  0x77, 0x6f, 0x72, 0x6c, 0x64, 0x2e, 0x72, 0x73],
             ]
         };
-        let mut reply: ReplyDirectory = Reply::new(0xdeadbeef, sender);
+        let mut reply = ReplyDirectory::new(0xdeadbeef, sender, 4096);
         reply.add(0xaabb, 1, FileType::Directory, "hello");
         reply.add(0xccdd, 2, FileType::RegularFile, "world.rs");
         reply.ok();

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -511,22 +511,16 @@ impl ReplyBmap {
 ///
 pub struct ReplyDirectory {
     reply: ReplyRaw<()>,
-    size: usize,
     data: Vec<u8>,
 }
 
-impl Reply for ReplyDirectory {
-    fn new<S: ReplySender> (unique: u64, sender: S) -> ReplyDirectory {
-        ReplyDirectory { reply: Reply::new(unique, sender), size: 0, data: Vec::with_capacity(4096) }
-    }
-}
-
 impl ReplyDirectory {
-    /// Changes the max size of the directory buffer
-    pub fn sized (mut self, size: usize) -> ReplyDirectory {
-        self.size = size;
-        self.data.reserve(size);
-        self
+    /// Creates a new ReplyDirectory with a specified buffer size.
+    pub fn new<S: ReplySender> (unique: u64, sender: S, size: usize) -> ReplyDirectory {
+        ReplyDirectory {
+            reply: Reply::new(unique, sender),
+            data: Vec::with_capacity(size),
+        }
     }
 
     /// Add an entry to the directory reply buffer. Returns true if the buffer is full.

--- a/src/request.rs
+++ b/src/request.rs
@@ -266,7 +266,7 @@ impl<'a> Request<'a> {
             FUSE_READDIR => {
                 let arg: &fuse_read_in = data.fetch();
                 debug!("READDIR({}) ino {:#018x}, fh {}, offset {}, size {}", self.header.unique, self.header.nodeid, arg.fh, arg.offset, arg.size);
-                se.filesystem.readdir(self, self.header.nodeid, arg.fh, arg.offset, self.reply::<ReplyDirectory>().sized(arg.size as usize));
+                se.filesystem.readdir(self, self.header.nodeid, arg.fh, arg.offset, ReplyDirectory::new(self.header.unique, self.ch, arg.size as usize));
             },
             FUSE_RELEASEDIR => {
                 let arg: &fuse_release_in = data.fetch();


### PR DESCRIPTION
This function is public, which implies that clients can change the size
of the reply buffer after being called by FUSE. In reality, this doesn't
work; the size is dictated by FUSE, and changing it results in an error.

Though this is an API change, any clients broken by this were broken
already -- they had a bug if they assumed this function worked. :)

The only minor ugliness is that now `ReplyDirectory` doesn't implement the `Reply` trait, but it needs the size to construct it properly, so the signature of `Reply::new` isn't really sufficient.