### PR TITLE
Add full stops to function docs: looks better in generated docs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,13 +97,13 @@ pub struct FileAttr {
 /// implementations are provided here to get a mountable filesystem that does
 /// nothing.
 pub trait Filesystem {
-    /// Initialize filesystem
+    /// Initialize filesystem.
     /// Called before any other filesystem method.
     fn init (&mut self, _req: &Request) -> Result<(), c_int> {
         Ok(())
     }
 
-    /// Clean up filesystem
+    /// Clean up filesystem.
     /// Called on filesystem exit.
     fn destroy (&mut self, _req: &Request) {
     }
@@ -113,7 +113,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Forget about an inode
+    /// Forget about an inode.
     /// The nlookup parameter indicates the number of lookups previously performed on
     /// this inode. If the filesystem implements inode lifetimes, it is recommended that
     /// inodes acquire a single reference on each lookup, and lose nlookup references on
@@ -123,58 +123,58 @@ pub trait Filesystem {
     fn forget (&mut self, _req: &Request, _ino: u64, _nlookup: u64) {
     }
 
-    /// Get file attributes
+    /// Get file attributes.
     fn getattr (&mut self, _req: &Request, _ino: u64, reply: ReplyAttr) {
         reply.error(ENOSYS);
     }
 
-    /// Set file attributes
+    /// Set file attributes.
     fn setattr (&mut self, _req: &Request, _ino: u64, _mode: Option<u32>, _uid: Option<u32>, _gid: Option<u32>, _size: Option<u64>, _atime: Option<Timespec>, _mtime: Option<Timespec>, _fh: Option<u64>, _crtime: Option<Timespec>, _chgtime: Option<Timespec>, _bkuptime: Option<Timespec>, _flags: Option<u32>, reply: ReplyAttr) {
         reply.error(ENOSYS);
     }
 
-    /// Read symbolic link
+    /// Read symbolic link.
     fn readlink (&mut self, _req: &Request, _ino: u64, reply: ReplyData) {
         reply.error(ENOSYS);
     }
 
-    /// Create file node
+    /// Create file node.
     /// Create a regular file, character device, block device, fifo or socket node.
     fn mknod (&mut self, _req: &Request, _parent: u64, _name: &Path, _mode: u32, _rdev: u32, reply: ReplyEntry) {
         reply.error(ENOSYS);
     }
 
-    /// Create a directory
+    /// Create a directory.
     fn mkdir (&mut self, _req: &Request, _parent: u64, _name: &Path, _mode: u32, reply: ReplyEntry) {
         reply.error(ENOSYS);
     }
 
-    /// Remove a file
+    /// Remove a file.
     fn unlink (&mut self, _req: &Request, _parent: u64, _name: &Path, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
-    /// Remove a directory
+    /// Remove a directory.
     fn rmdir (&mut self, _req: &Request, _parent: u64, _name: &Path, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
-    /// Create a symbolic link
+    /// Create a symbolic link.
     fn symlink (&mut self, _req: &Request, _parent: u64, _name: &Path, _link: &Path, reply: ReplyEntry) {
         reply.error(ENOSYS);
     }
 
-    /// Rename a file
+    /// Rename a file.
     fn rename (&mut self, _req: &Request, _parent: u64, _name: &Path, _newparent: u64, _newname: &Path, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
-    /// Create a hard link
+    /// Create a hard link.
     fn link (&mut self, _req: &Request, _ino: u64, _newparent: u64, _newname: &Path, reply: ReplyEntry) {
         reply.error(ENOSYS);
     }
 
-    /// Open a file
+    /// Open a file.
     /// Open flags (with the exception of O_CREAT, O_EXCL, O_NOCTTY and O_TRUNC) are
     /// available in flags. Filesystem may store an arbitrary file handle (pointer, index,
     /// etc) in fh, and use this in other all other file operations (read, write, flush,
@@ -186,7 +186,7 @@ pub trait Filesystem {
         reply.opened(0, 0);
     }
 
-    /// Read data
+    /// Read data.
     /// Read should send exactly the number of bytes requested except on EOF or error,
     /// otherwise the rest of the data will be substituted with zeroes. An exception to
     /// this is when the file has been opened in 'direct_io' mode, in which case the
@@ -197,7 +197,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Write data
+    /// Write data.
     /// Write should return exactly the number of bytes requested except on error. An
     /// exception to this is when the file has been opened in 'direct_io' mode, in
     /// which case the return value of the write system call will reflect the return
@@ -207,7 +207,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Flush method
+    /// Flush method.
     /// This is called on each close() of the opened file. Since file descriptors can
     /// be duplicated (dup, dup2, fork), for one open call there may be many flush
     /// calls. Filesystems shouldn't assume that flush will always be called after some
@@ -221,7 +221,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Release an open file
+    /// Release an open file.
     /// Release is called when there are no more references to an open file: all file
     /// descriptors are closed and all memory mappings are unmapped. For every open
     /// call there will be exactly one release call. The filesystem may reply with an
@@ -233,14 +233,14 @@ pub trait Filesystem {
         reply.ok();
     }
 
-    /// Synchronize file contents
+    /// Synchronize file contents.
     /// If the datasync parameter is non-zero, then only the user data should be flushed,
     /// not the meta data.
     fn fsync (&mut self, _req: &Request, _ino: u64, _fh: u64, _datasync: bool, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
-    /// Open a directory
+    /// Open a directory.
     /// Filesystem may store an arbitrary file handle (pointer, index, etc) in fh, and
     /// use this in other all other directory stream operations (readdir, releasedir,
     /// fsyncdir). Filesystem may also implement stateless directory I/O and not store
@@ -251,7 +251,7 @@ pub trait Filesystem {
         reply.opened(0, 0);
     }
 
-    /// Read directory
+    /// Read directory.
     /// Send a buffer filled using buffer.fill(), with size not exceeding the
     /// requested size. Send an empty buffer on end of stream. fh will contain the
     /// value set by the opendir method, or will be undefined if the opendir method
@@ -260,7 +260,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Release an open directory
+    /// Release an open directory.
     /// For every opendir call there will be exactly one releasedir call. fh will
     /// contain the value set by the opendir method, or will be undefined if the
     /// opendir method didn't set any value.
@@ -268,7 +268,7 @@ pub trait Filesystem {
         reply.ok();
     }
 
-    /// Synchronize directory contents
+    /// Synchronize directory contents.
     /// If the datasync parameter is set, then only the directory contents should
     /// be flushed, not the meta data. fh will contain the value set by the opendir
     /// method, or will be undefined if the opendir method didn't set any value.
@@ -276,36 +276,36 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Get file system statistics
+    /// Get file system statistics.
     fn statfs (&mut self, _req: &Request, _ino: u64, reply: ReplyStatfs) {
         reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
     }
 
-    /// Set an extended attribute
+    /// Set an extended attribute.
     fn setxattr (&mut self, _req: &Request, _ino: u64, _name: &OsStr, _value: &[u8], _flags: u32, _position: u32, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
-    /// Get an extended attribute
+    /// Get an extended attribute.
     fn getxattr (&mut self, _req: &Request, _ino: u64, _name: &OsStr, reply: ReplyData) {
         // FIXME: If arg.size is zero, the size of the value should be sent with fuse_getxattr_out
         // FIXME: If arg.size is non-zero, send the value if it fits, or ERANGE otherwise
         reply.error(ENOSYS);
     }
 
-    /// List extended attribute names
+    /// List extended attribute names.
     fn listxattr (&mut self, _req: &Request, _ino: u64, reply: ReplyEmpty) {
         // FIXME: If arg.size is zero, the size of the attribute list should be sent with fuse_getxattr_out
         // FIXME: If arg.size is non-zero, send the attribute list if it fits, or ERANGE otherwise
         reply.error(ENOSYS);
     }
 
-    /// Remove an extended attribute
+    /// Remove an extended attribute.
     fn removexattr (&mut self, _req: &Request, _ino: u64, _name: &OsStr, reply: ReplyEmpty) {
         reply.error(ENOSYS);
     }
 
-    /// Check file access permissions
+    /// Check file access permissions.
     /// This will be called for the access() system call. If the 'default_permissions'
     /// mount option is given, this method is not called. This method is not called
     /// under Linux kernel versions 2.4.x
@@ -313,7 +313,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Create and open a file
+    /// Create and open a file.
     /// If the file does not exist, first create it with the specified mode, and then
     /// open it. Open flags (with the exception of O_NOCTTY) are available in flags.
     /// Filesystem may store an arbitrary file handle (pointer, index, etc) in fh,
@@ -327,12 +327,12 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Test for a POSIX file lock
+    /// Test for a POSIX file lock.
     fn getlk (&mut self, _req: &Request, _ino: u64, _fh: u64, _lock_owner: u64, _start: u64, _end: u64, _typ: u32, _pid: u32, reply: ReplyLock) {
         reply.error(ENOSYS);
     }
 
-    /// Acquire, modify or release a POSIX file lock
+    /// Acquire, modify or release a POSIX file lock.
     /// For POSIX threads (NPTL) there's a 1-1 relation between pid and owner, but
     /// otherwise this is not always the case.  For checking lock ownership,
     /// 'fi->owner' must be used. The l_pid field in 'struct flock' should only be
@@ -343,7 +343,7 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Map block index within file to block index within device
+    /// Map block index within file to block index within device.
     /// Note: This makes sense only for block device backed filesystems mounted
     /// with the 'blkdev' option
     fn bmap (&mut self, _req: &Request, _ino: u64, _blocksize: u32, _idx: u64, reply: ReplyBmap) {


### PR DESCRIPTION
Hi Andreas,

The generated docs for the methods of `fuse::Filesystem` look a bit funny, for instance `Initialize filesystem Called before any other filesystem method.`. This patch adds a full stop in between there.

Cheers, Bram