### PR TITLE
Fix the listxattr and getxattr functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use fuse::FUSE_ROOT_ID;
 pub use fuse::consts;
 pub use reply::{Reply, ReplyEmpty, ReplyData, ReplyEntry, ReplyAttr, ReplyOpen};
 pub use reply::{ReplyWrite, ReplyStatfs, ReplyCreate, ReplyLock, ReplyBmap, ReplyDirectory};
+pub use reply::ReplyXattr;
 #[cfg(target_os = "macos")]
 pub use reply::ReplyXTimes;
 pub use request::Request;
@@ -286,17 +287,19 @@ pub trait Filesystem {
         reply.error(ENOSYS);
     }
 
-    /// Get an extended attribute
-    fn getxattr (&mut self, _req: &Request, _ino: u64, _name: &OsStr, reply: ReplyData) {
-        // FIXME: If arg.size is zero, the size of the value should be sent with fuse_getxattr_out
-        // FIXME: If arg.size is non-zero, send the value if it fits, or ERANGE otherwise
+    /// Get an extended attribute.
+    /// If `size` is 0, the size of the value should be sent with `reply.size()`.
+    /// If `size` is not 0, and the value fits, send it with `reply.data()`, or
+    /// `reply.error(ERANGE)` if it doesn't.
+    fn getxattr (&mut self, _req: &Request, _ino: u64, _name: &OsStr, _size: u32, reply: ReplyXattr) {
         reply.error(ENOSYS);
     }
 
     /// List extended attribute names
-    fn listxattr (&mut self, _req: &Request, _ino: u64, reply: ReplyEmpty) {
-        // FIXME: If arg.size is zero, the size of the attribute list should be sent with fuse_getxattr_out
-        // FIXME: If arg.size is non-zero, send the attribute list if it fits, or ERANGE otherwise
+    /// If `size` is 0, the size of the value should be sent with `reply.size()`.
+    /// If `size` is not 0, and the value fits, send it with `reply.data()`, or
+    /// `reply.error(ERANGE)` if it doesn't.
+    fn listxattr (&mut self, _req: &Request, _ino: u64, _size: u32, reply: ReplyXattr) {
         reply.error(ENOSYS);
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -300,12 +300,12 @@ impl<'a> Request<'a> {
                 let arg: &fuse_getxattr_in = data.fetch();
                 let name = data.fetch_str();
                 debug!("GETXATTR({}) ino {:#018x}, name {:?}, size {}", self.header.unique, self.header.nodeid, name, arg.size);
-                se.filesystem.getxattr(self, self.header.nodeid, name, self.reply());
+                se.filesystem.getxattr(self, self.header.nodeid, name, arg.size, self.reply());
             },
             FUSE_LISTXATTR => {
                 let arg: &fuse_getxattr_in = data.fetch();
                 debug!("LISTXATTR({}) ino {:#018x}, size {}", self.header.unique, self.header.nodeid, arg.size);
-                se.filesystem.listxattr(self, self.header.nodeid, self.reply());
+                se.filesystem.listxattr(self, self.header.nodeid, arg.size, self.reply());
             },
             FUSE_REMOVEXATTR => {
                 let name = data.fetch_str();


### PR DESCRIPTION
Created a new reply type to allow sending the `fuse_getxattr_out`
structure that is needed to tell the system about the xattr list and
data buffer sizes.

This is a breaking change, because it changes API function signatures, but the existing `listxattr` and `getxattr` weren't actually usable anyway.

This was fun to implement. The way the `Reply` trait works made it a total breeze. 🍰 