### PR TITLE
Replace a forgotten Path by an OsStr in symlink()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub trait Filesystem {
     }
 
     /// Create a symbolic link.
-    fn symlink (&mut self, _req: &Request, _parent: u64, _name: &OsStr, _link: &Path, reply: ReplyEntry) {
+    fn symlink (&mut self, _req: &Request, _parent: u64, _name: &OsStr, _link: &OsStr, reply: ReplyEntry) {
         reply.error(ENOSYS);
     }
 


### PR DESCRIPTION
I guess _link should probably be an OsStr too, right ?