### PR TITLE
use signed integer for offsets

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -68,7 +68,7 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn read (&mut self, _req: &Request, ino: u64, _fh: u64, offset: u64, _size: u32, reply: ReplyData) {
+    fn read (&mut self, _req: &Request, ino: u64, _fh: u64, offset: i64, _size: u32, reply: ReplyData) {
         if ino == 2 {
             reply.data(&HELLO_TXT_CONTENT.as_bytes()[offset as usize..]);
         } else {
@@ -76,7 +76,7 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn readdir (&mut self, _req: &Request, ino: u64, _fh: u64, offset: u64, mut reply: ReplyDirectory) {
+    fn readdir (&mut self, _req: &Request, ino: u64, _fh: u64, offset: i64, mut reply: ReplyDirectory) {
         if ino == 1 {
             if offset == 0 {
                 reply.add(1, 0, FileType::Directory, ".");

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -371,7 +371,7 @@ pub struct fuse_flush_in {
 #[derive(Debug)]
 pub struct fuse_read_in {
     pub fh: u64,
-    pub offset: u64,
+    pub offset: i64,
     pub size: u32,
     pub padding: u32,
 }
@@ -380,7 +380,7 @@ pub struct fuse_read_in {
 #[derive(Debug)]
 pub struct fuse_write_in {
     pub fh: u64,
-    pub offset: u64,
+    pub offset: i64,
     pub size: u32,
     pub write_flags: u32,
 }
@@ -521,7 +521,7 @@ pub struct fuse_out_header {
 #[derive(Debug)]
 pub struct fuse_dirent {
     pub ino: u64,
-    pub off: u64,
+    pub off: i64,
     pub namelen: u32,
     pub typ: u32,
     // followed by name of namelen bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub trait Filesystem {
     /// return value of the read system call will reflect the return value of this
     /// operation. fh will contain the value set by the open method, or will be undefined
     /// if the open method didn't set any value.
-    fn read (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, _size: u32, reply: ReplyData) {
+    fn read (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: i64, _size: u32, reply: ReplyData) {
         reply.error(ENOSYS);
     }
 
@@ -204,7 +204,7 @@ pub trait Filesystem {
     /// which case the return value of the write system call will reflect the return
     /// value of this operation. fh will contain the value set by the open method, or
     /// will be undefined if the open method didn't set any value.
-    fn write (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, _data: &[u8], _flags: u32, reply: ReplyWrite) {
+    fn write (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: i64, _data: &[u8], _flags: u32, reply: ReplyWrite) {
         reply.error(ENOSYS);
     }
 
@@ -257,7 +257,7 @@ pub trait Filesystem {
     /// requested size. Send an empty buffer on end of stream. fh will contain the
     /// value set by the opendir method, or will be undefined if the opendir method
     /// didn't set any value.
-    fn readdir (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: u64, reply: ReplyDirectory) {
+    fn readdir (&mut self, _req: &Request, _ino: u64, _fh: u64, _offset: i64, reply: ReplyDirectory) {
         reply.error(ENOSYS);
     }
 

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -547,7 +547,7 @@ impl ReplyDirectory {
     /// Add an entry to the directory reply buffer. Returns true if the buffer is full.
     /// A transparent offset value can be provided for each entry. The kernel uses these
     /// value to request the next entries in further readdir calls
-    pub fn add<T: AsRef<OsStr>> (&mut self, ino: u64, offset: u64, kind: FileType, name: T) -> bool {
+    pub fn add<T: AsRef<OsStr>> (&mut self, ino: u64, offset: i64, kind: FileType, name: T) -> bool {
         let name = name.as_ref().as_bytes();
         let entlen = mem::size_of::<fuse_dirent>() + name.len();
         let entsize = (entlen + mem::size_of::<u64>() - 1) & !(mem::size_of::<u64>() - 1);  // 64bit align


### PR DESCRIPTION
libfuse (off_t), linux kernel (loff_t) as well as POSIX (fseek, seekdir,
...) use signed integers for file offsets, so rust-fuse should probably
too.
