### PR TITLE
size is also of signed (off_t)

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -39,7 +39,7 @@ pub const FUSE_ROOT_ID: u64 = 1;
 #[derive(Debug)]
 pub struct fuse_attr {
     pub ino: u64,
-    pub size: u64,
+    pub size: i64,
     pub blocks: u64,
     pub atime: i64,
     pub mtime: i64,
@@ -305,7 +305,7 @@ pub struct fuse_setattr_in {
     pub valid: u32,
     pub padding: u32,
     pub fh: u64,
-    pub size: u64,
+    pub size: i64,
     pub unused1: u64,
     pub atime: i64,
     pub mtime: i64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub struct FileAttr {
     /// Inode number
     pub ino: u64,
     /// Size in bytes
-    pub size: u64,
+    pub size: i64,
     /// Size in blocks
     pub blocks: u64,
     /// Time of last access
@@ -130,7 +130,7 @@ pub trait Filesystem {
     }
 
     /// Set file attributes.
-    fn setattr (&mut self, _req: &Request, _ino: u64, _mode: Option<u32>, _uid: Option<u32>, _gid: Option<u32>, _size: Option<u64>, _atime: Option<Timespec>, _mtime: Option<Timespec>, _fh: Option<u64>, _crtime: Option<Timespec>, _chgtime: Option<Timespec>, _bkuptime: Option<Timespec>, _flags: Option<u32>, reply: ReplyAttr) {
+    fn setattr (&mut self, _req: &Request, _ino: u64, _mode: Option<u32>, _uid: Option<u32>, _gid: Option<u32>, _size: Option<i64>, _atime: Option<Timespec>, _mtime: Option<Timespec>, _fh: Option<u64>, _crtime: Option<Timespec>, _chgtime: Option<Timespec>, _bkuptime: Option<Timespec>, _flags: Option<u32>, reply: ReplyAttr) {
         reply.error(ENOSYS);
     }
 


### PR DESCRIPTION
follow up of 39c98bae89899fea487c26334a76d319df0a1180