### PR TITLE
upgrade the env_logger dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ time = "0.1"
 thread-scoped = "1"
 
 [dev-dependencies]
-env_logger = "0.3"
+env_logger = "0.5"
 
 [lib]
 name = "fuse"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -91,7 +91,7 @@ impl Filesystem for HelloFS {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
     fuse::mount(HelloFS, &mountpoint, &[]).unwrap();
 }

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -9,7 +9,7 @@ struct NullFS;
 impl Filesystem for NullFS {}
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
     fuse::mount(NullFS, &mountpoint, &[]).unwrap();
 }


### PR DESCRIPTION
The latest version no longer returns a result from init(), so the
examples needed to be tweaked.