### PR TITLE
Remove mountpoint reference from {,spawn_}mount()

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -97,5 +97,5 @@ fn main() {
         .iter()
         .map(|o| o.as_ref())
         .collect::<Vec<&OsStr>>();
-    fuse::mount(HelloFS, &mountpoint, &options).unwrap();
+    fuse::mount(HelloFS, mountpoint, &options).unwrap();
 }

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -11,5 +11,5 @@ impl Filesystem for NullFS {}
 fn main() {
     env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
-    fuse::mount(NullFS, &mountpoint, &[]).unwrap();
+    fuse::mount(NullFS, mountpoint, &[]).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ pub trait Filesystem {
 ///
 /// Note that you need to lead each option with a separate `"-o"` string. See
 /// `examples/hello.rs`.
-pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: &P, options: &[&OsStr]) -> io::Result<()>{
+pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr]) -> io::Result<()>{
     Session::new(filesystem, mountpoint.as_ref(), options).and_then(|mut se| se.run())
 }
 
@@ -384,6 +384,6 @@ pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: &P, opt
 /// and therefore returns immediately. The returned handle should be stored
 /// to reference the mounted filesystem. If it's dropped, the filesystem will
 /// be unmounted.
-pub unsafe fn spawn_mount<'a, FS: Filesystem+Send+'a, P: AsRef<Path>>(filesystem: FS, mountpoint: &P, options: &[&OsStr]) -> io::Result<BackgroundSession<'a>> {
+pub unsafe fn spawn_mount<'a, FS: Filesystem+Send+'a, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr]) -> io::Result<BackgroundSession<'a>> {
     Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn())
 }


### PR DESCRIPTION
The mount() and spawn_mount() calls define mountpoint as a &P but
P is already an AsRef<Path>.  This prevents passing the mountpoint
to these calls when it is already a reference without having to take
an additional reference to it.  For example:

fn foo(mountpoint: &Path) {
    fuse::mount(..., mountpoint, ...);
    ...
}

does not compile without passing mountpoint as &mountpoint to the
fuse::mount() call, but there is no reason that it should not.

To fix this, remove the extra reference reference qualifier.