### PR TITLE
Make FileType and FileAttr fully comparable

### DIFF
--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -37,7 +37,7 @@ mod request;
 mod session;
 
 /// File types
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FileType {
     /// Named pipe (S_IFIFO)
     NamedPipe,
@@ -56,7 +56,7 @@ pub enum FileType {
 }
 
 /// File attributes
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FileAttr {
     /// Inode number
     pub ino: u64,


### PR DESCRIPTION
There is no reason these two types shouldn't be PartialEq and Eq, so
make them be.  Having them be comparable is very useful for unit testing.

Motivated by the tests in:
https://github.com/bazelbuild/sandboxfs/blob/6758dcf48d09ac06db475b0137cda373748227ff/src/nodes/conv.rs#L283