### PR TITLE
chore: remove deprecated time crate

### DIFF
--- a/fuse-sys/src/abi.rs
+++ b/fuse-sys/src/abi.rs
@@ -47,20 +47,20 @@ pub struct fuse_attr {
     pub gid: u32,
     pub rdev: u32,
     #[cfg(target_os = "macos")]
-    pub flags: u32, // see chflags(2)
+    pub flags: u32,                                     // see chflags(2)
 }
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct fuse_kstatfs {
-    pub blocks: u64,  // Total blocks (in units of frsize)
-    pub bfree: u64,   // Free blocks
-    pub bavail: u64,  // Free blocks for unprivileged users
-    pub files: u64,   // Total inodes
-    pub ffree: u64,   // Free inodes
-    pub bsize: u32,   // Filesystem block size
-    pub namelen: u32, // Maximum filename length
-    pub frsize: u32,  // Fundamental file system block size
+    pub blocks: u64,                                    // Total blocks (in units of frsize)
+    pub bfree: u64,                                     // Free blocks
+    pub bavail: u64,                                    // Free blocks for unprivileged users
+    pub files: u64,                                     // Total inodes
+    pub ffree: u64,                                     // Free inodes
+    pub bsize: u32,                                     // Filesystem block size
+    pub namelen: u32,                                   // Maximum filename length
+    pub frsize: u32,                                    // Fundamental file system block size
     pub padding: u32,
     pub spare: [u32; 6],
 }
@@ -76,45 +76,45 @@ pub struct fuse_file_lock {
 
 pub mod consts {
     // Bitmasks for fuse_setattr_in.valid
-    pub const FATTR_MODE: u32 = 1 << 0;
-    pub const FATTR_UID: u32 = 1 << 1;
-    pub const FATTR_GID: u32 = 1 << 2;
-    pub const FATTR_SIZE: u32 = 1 << 3;
-    pub const FATTR_ATIME: u32 = 1 << 4;
-    pub const FATTR_MTIME: u32 = 1 << 5;
-    pub const FATTR_FH: u32 = 1 << 6;
+    pub const FATTR_MODE: u32               = 1 << 0;
+    pub const FATTR_UID: u32                = 1 << 1;
+    pub const FATTR_GID: u32                = 1 << 2;
+    pub const FATTR_SIZE: u32               = 1 << 3;
+    pub const FATTR_ATIME: u32              = 1 << 4;
+    pub const FATTR_MTIME: u32              = 1 << 5;
+    pub const FATTR_FH: u32                 = 1 << 6;
     #[cfg(target_os = "macos")]
-    pub const FATTR_CRTIME: u32 = 1 << 28;
+    pub const FATTR_CRTIME: u32             = 1 << 28;
     #[cfg(target_os = "macos")]
-    pub const FATTR_CHGTIME: u32 = 1 << 29;
+    pub const FATTR_CHGTIME: u32            = 1 << 29;
     #[cfg(target_os = "macos")]
-    pub const FATTR_BKUPTIME: u32 = 1 << 30;
+    pub const FATTR_BKUPTIME: u32           = 1 << 30;
     #[cfg(target_os = "macos")]
-    pub const FATTR_FLAGS: u32 = 1 << 31;
+    pub const FATTR_FLAGS: u32              = 1 << 31;
 
     // Flags returned by the open request
-    pub const FOPEN_DIRECT_IO: u32 = 1 << 0; // bypass page cache for this open file
-    pub const FOPEN_KEEP_CACHE: u32 = 1 << 1; // don't invalidate the data cache on open
+    pub const FOPEN_DIRECT_IO: u32          = 1 << 0;   // bypass page cache for this open file
+    pub const FOPEN_KEEP_CACHE: u32         = 1 << 1;   // don't invalidate the data cache on open
     #[cfg(target_os = "macos")]
-    pub const FOPEN_PURGE_ATTR: u32 = 1 << 30;
+    pub const FOPEN_PURGE_ATTR: u32         = 1 << 30;
     #[cfg(target_os = "macos")]
-    pub const FOPEN_PURGE_UBC: u32 = 1 << 31;
+    pub const FOPEN_PURGE_UBC: u32          = 1 << 31;
 
     // Init request/reply flags
-    pub const FUSE_ASYNC_READ: u32 = 1 << 0;
-    pub const FUSE_POSIX_LOCKS: u32 = 1 << 1;
+    pub const FUSE_ASYNC_READ: u32          = 1 << 0;
+    pub const FUSE_POSIX_LOCKS: u32         = 1 << 1;
     #[cfg(target_os = "macos")]
-    pub const FUSE_CASE_INSENSITIVE: u32 = 1 << 29;
+    pub const FUSE_CASE_INSENSITIVE: u32    = 1 << 29;
     #[cfg(target_os = "macos")]
-    pub const FUSE_VOL_RENAME: u32 = 1 << 30;
+    pub const FUSE_VOL_RENAME: u32          = 1 << 30;
     #[cfg(target_os = "macos")]
-    pub const FUSE_XTIMES: u32 = 1 << 31;
+    pub const FUSE_XTIMES: u32              = 1 << 31;
 
     // Release flags
-    pub const FUSE_RELEASE_FLUSH: u32 = 1 << 0;
+    pub const FUSE_RELEASE_FLUSH: u32       = 1 << 0;
 
     // The read buffer is required to be at least 8k, but may be much larger
-    pub const FUSE_MIN_READ_BUFFER: usize = 8192;
+    pub const FUSE_MIN_READ_BUFFER: usize   = 8192;
 }
 
 #[repr(C)]
@@ -122,7 +122,7 @@ pub mod consts {
 #[allow(non_camel_case_types)]
 pub enum fuse_opcode {
     FUSE_LOOKUP = 1,
-    FUSE_FORGET = 2, // no reply
+    FUSE_FORGET = 2,                                    // no reply
     FUSE_GETATTR = 3,
     FUSE_SETATTR = 4,
     FUSE_READLINK = 5,
@@ -320,7 +320,7 @@ pub struct fuse_setattr_in {
     #[cfg(target_os = "macos")]
     pub crtimensec: u32,
     #[cfg(target_os = "macos")]
-    pub flags: u32, // see chflags(2)
+    pub flags: u32,                                     // see chflags(2)
 }
 
 #[repr(C)]

--- a/fuse-sys/src/abi.rs
+++ b/fuse-sys/src/abi.rs
@@ -31,36 +31,36 @@ pub struct fuse_attr {
     pub ino: u64,
     pub size: u64,
     pub blocks: u64,
-    pub atime: i64,
-    pub mtime: i64,
-    pub ctime: i64,
+    pub atime: u64,
+    pub mtime: u64,
+    pub ctime: u64,
     #[cfg(target_os = "macos")]
-    pub crtime: i64,
-    pub atimensec: i32,
-    pub mtimensec: i32,
-    pub ctimensec: i32,
+    pub crtime: u64,
+    pub atimensec: u32,
+    pub mtimensec: u32,
+    pub ctimensec: u32,
     #[cfg(target_os = "macos")]
-    pub crtimensec: i32,
+    pub crtimensec: u32,
     pub mode: u32,
     pub nlink: u32,
     pub uid: u32,
     pub gid: u32,
     pub rdev: u32,
     #[cfg(target_os = "macos")]
-    pub flags: u32,                                     // see chflags(2)
+    pub flags: u32, // see chflags(2)
 }
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct fuse_kstatfs {
-    pub blocks: u64,                                    // Total blocks (in units of frsize)
-    pub bfree: u64,                                     // Free blocks
-    pub bavail: u64,                                    // Free blocks for unprivileged users
-    pub files: u64,                                     // Total inodes
-    pub ffree: u64,                                     // Free inodes
-    pub bsize: u32,                                     // Filesystem block size
-    pub namelen: u32,                                   // Maximum filename length
-    pub frsize: u32,                                    // Fundamental file system block size
+    pub blocks: u64,  // Total blocks (in units of frsize)
+    pub bfree: u64,   // Free blocks
+    pub bavail: u64,  // Free blocks for unprivileged users
+    pub files: u64,   // Total inodes
+    pub ffree: u64,   // Free inodes
+    pub bsize: u32,   // Filesystem block size
+    pub namelen: u32, // Maximum filename length
+    pub frsize: u32,  // Fundamental file system block size
     pub padding: u32,
     pub spare: [u32; 6],
 }
@@ -76,45 +76,45 @@ pub struct fuse_file_lock {
 
 pub mod consts {
     // Bitmasks for fuse_setattr_in.valid
-    pub const FATTR_MODE: u32               = 1 << 0;
-    pub const FATTR_UID: u32                = 1 << 1;
-    pub const FATTR_GID: u32                = 1 << 2;
-    pub const FATTR_SIZE: u32               = 1 << 3;
-    pub const FATTR_ATIME: u32              = 1 << 4;
-    pub const FATTR_MTIME: u32              = 1 << 5;
-    pub const FATTR_FH: u32                 = 1 << 6;
+    pub const FATTR_MODE: u32 = 1 << 0;
+    pub const FATTR_UID: u32 = 1 << 1;
+    pub const FATTR_GID: u32 = 1 << 2;
+    pub const FATTR_SIZE: u32 = 1 << 3;
+    pub const FATTR_ATIME: u32 = 1 << 4;
+    pub const FATTR_MTIME: u32 = 1 << 5;
+    pub const FATTR_FH: u32 = 1 << 6;
     #[cfg(target_os = "macos")]
-    pub const FATTR_CRTIME: u32             = 1 << 28;
+    pub const FATTR_CRTIME: u32 = 1 << 28;
     #[cfg(target_os = "macos")]
-    pub const FATTR_CHGTIME: u32            = 1 << 29;
+    pub const FATTR_CHGTIME: u32 = 1 << 29;
     #[cfg(target_os = "macos")]
-    pub const FATTR_BKUPTIME: u32           = 1 << 30;
+    pub const FATTR_BKUPTIME: u32 = 1 << 30;
     #[cfg(target_os = "macos")]
-    pub const FATTR_FLAGS: u32              = 1 << 31;
+    pub const FATTR_FLAGS: u32 = 1 << 31;
 
     // Flags returned by the open request
-    pub const FOPEN_DIRECT_IO: u32          = 1 << 0;   // bypass page cache for this open file
-    pub const FOPEN_KEEP_CACHE: u32         = 1 << 1;   // don't invalidate the data cache on open
+    pub const FOPEN_DIRECT_IO: u32 = 1 << 0; // bypass page cache for this open file
+    pub const FOPEN_KEEP_CACHE: u32 = 1 << 1; // don't invalidate the data cache on open
     #[cfg(target_os = "macos")]
-    pub const FOPEN_PURGE_ATTR: u32         = 1 << 30;
+    pub const FOPEN_PURGE_ATTR: u32 = 1 << 30;
     #[cfg(target_os = "macos")]
-    pub const FOPEN_PURGE_UBC: u32          = 1 << 31;
+    pub const FOPEN_PURGE_UBC: u32 = 1 << 31;
 
     // Init request/reply flags
-    pub const FUSE_ASYNC_READ: u32          = 1 << 0;
-    pub const FUSE_POSIX_LOCKS: u32         = 1 << 1;
+    pub const FUSE_ASYNC_READ: u32 = 1 << 0;
+    pub const FUSE_POSIX_LOCKS: u32 = 1 << 1;
     #[cfg(target_os = "macos")]
-    pub const FUSE_CASE_INSENSITIVE: u32    = 1 << 29;
+    pub const FUSE_CASE_INSENSITIVE: u32 = 1 << 29;
     #[cfg(target_os = "macos")]
-    pub const FUSE_VOL_RENAME: u32          = 1 << 30;
+    pub const FUSE_VOL_RENAME: u32 = 1 << 30;
     #[cfg(target_os = "macos")]
-    pub const FUSE_XTIMES: u32              = 1 << 31;
+    pub const FUSE_XTIMES: u32 = 1 << 31;
 
     // Release flags
-    pub const FUSE_RELEASE_FLUSH: u32       = 1 << 0;
+    pub const FUSE_RELEASE_FLUSH: u32 = 1 << 0;
 
     // The read buffer is required to be at least 8k, but may be much larger
-    pub const FUSE_MIN_READ_BUFFER: usize   = 8192;
+    pub const FUSE_MIN_READ_BUFFER: usize = 8192;
 }
 
 #[repr(C)]
@@ -122,7 +122,7 @@ pub mod consts {
 #[allow(non_camel_case_types)]
 pub enum fuse_opcode {
     FUSE_LOOKUP = 1,
-    FUSE_FORGET = 2,                                    // no reply
+    FUSE_FORGET = 2, // no reply
     FUSE_GETATTR = 3,
     FUSE_SETATTR = 4,
     FUSE_READLINK = 5,
@@ -221,10 +221,10 @@ impl fuse_opcode {
 pub struct fuse_entry_out {
     pub nodeid: u64,
     pub generation: u64,
-    pub entry_valid: i64,
-    pub attr_valid: i64,
-    pub entry_valid_nsec: i32,
-    pub attr_valid_nsec: i32,
+    pub entry_valid: u64,
+    pub attr_valid: u64,
+    pub entry_valid_nsec: u32,
+    pub attr_valid_nsec: u32,
     pub attr: fuse_attr,
 }
 
@@ -237,8 +237,8 @@ pub struct fuse_forget_in {
 #[repr(C)]
 #[derive(Debug)]
 pub struct fuse_attr_out {
-    pub attr_valid: i64,
-    pub attr_valid_nsec: i32,
+    pub attr_valid: u64,
+    pub attr_valid_nsec: u32,
     pub dummy: u32,
     pub attr: fuse_attr,
 }
@@ -247,10 +247,10 @@ pub struct fuse_attr_out {
 #[repr(C)]
 #[derive(Debug)]
 pub struct fuse_getxtimes_out {
-    pub bkuptime: i64,
-    pub crtime: i64,
-    pub bkuptimensec: i32,
-    pub crtimensec: i32,
+    pub bkuptime: u64,
+    pub crtime: u64,
+    pub bkuptimensec: u32,
+    pub crtimensec: u32,
 }
 
 #[repr(C)]
@@ -296,11 +296,11 @@ pub struct fuse_setattr_in {
     pub fh: u64,
     pub size: u64,
     pub unused1: u64,
-    pub atime: i64,
-    pub mtime: i64,
+    pub atime: u64,
+    pub mtime: u64,
     pub unused2: u64,
-    pub atimensec: i32,
-    pub mtimensec: i32,
+    pub atimensec: u32,
+    pub mtimensec: u32,
     pub unused3: u32,
     pub mode: u32,
     pub unused4: u32,
@@ -308,19 +308,19 @@ pub struct fuse_setattr_in {
     pub gid: u32,
     pub unused5: u32,
     #[cfg(target_os = "macos")]
-    pub bkuptime: i64,
+    pub bkuptime: u64,
     #[cfg(target_os = "macos")]
-    pub chgtime: i64,
+    pub chgtime: u64,
     #[cfg(target_os = "macos")]
-    pub crtime: i64,
+    pub crtime: u64,
     #[cfg(target_os = "macos")]
-    pub bkuptimensec: i32,
+    pub bkuptimensec: u32,
     #[cfg(target_os = "macos")]
-    pub chgtimensec: i32,
+    pub chgtimensec: u32,
     #[cfg(target_os = "macos")]
-    pub crtimensec: i32,
+    pub crtimensec: u32,
     #[cfg(target_os = "macos")]
-    pub flags: u32,                                     // see chflags(2)
+    pub flags: u32, // see chflags(2)
 }
 
 #[repr(C)]

--- a/fuse/Cargo.toml
+++ b/fuse/Cargo.toml
@@ -18,8 +18,8 @@ travis-ci = { repository = "zargony/rust-fuse" }
 fuse-sys = { path = "../fuse-sys", version = "0.4.0-alpha" }
 libc = "0.2"
 log = "0.3"
-time = "0.1"
 thread-scoped = "1"
 
 [dev-dependencies]
 env_logger = "0.5"
+lazy_static = "1.2.0"

--- a/fuse/examples/hello.rs
+++ b/fuse/examples/hello.rs
@@ -1,53 +1,58 @@
 extern crate env_logger;
+#[macro_use]
+extern crate lazy_static;
 extern crate fuse;
 extern crate libc;
-extern crate time;
 
 use std::env;
 use std::ffi::OsStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use libc::ENOENT;
-use time::Timespec;
 use fuse::{FileType, FileAttr, Filesystem, Request, ReplyData, ReplyEntry, ReplyAttr, ReplyDirectory};
 
-const TTL: Timespec = Timespec { sec: 1, nsec: 0 };                     // 1 second
+lazy_static! {
+    // 1 second
+    static ref TTL: Duration = Duration::new(1, 0);
 
-const CREATE_TIME: Timespec = Timespec { sec: 1381237736, nsec: 0 };    // 2013-10-08 08:56
+    // 2013-10-08 08:56
+    static ref CREATE_TIME: SystemTime = UNIX_EPOCH + Duration::new(1381237736, 0);
 
-const HELLO_DIR_ATTR: FileAttr = FileAttr {
-    ino: 1,
-    size: 0,
-    blocks: 0,
-    atime: CREATE_TIME,
-    mtime: CREATE_TIME,
-    ctime: CREATE_TIME,
-    crtime: CREATE_TIME,
-    kind: FileType::Directory,
-    perm: 0o755,
-    nlink: 2,
-    uid: 501,
-    gid: 20,
-    rdev: 0,
-    flags: 0,
-};
+    static ref HELLO_DIR_ATTR: FileAttr = FileAttr {
+        ino: 1,
+        size: 0,
+        blocks: 0,
+        atime: *CREATE_TIME,
+        mtime: *CREATE_TIME,
+        ctime: *CREATE_TIME,
+        crtime: *CREATE_TIME,
+        kind: FileType::Directory,
+        perm: 0o755,
+        nlink: 2,
+        uid: 501,
+        gid: 20,
+        rdev: 0,
+        flags: 0,
+    };
 
-const HELLO_TXT_CONTENT: &'static str = "Hello World!\n";
+    static ref HELLO_TXT_CONTENT: &'static str = "Hello World!\n";
 
-const HELLO_TXT_ATTR: FileAttr = FileAttr {
-    ino: 2,
-    size: 13,
-    blocks: 1,
-    atime: CREATE_TIME,
-    mtime: CREATE_TIME,
-    ctime: CREATE_TIME,
-    crtime: CREATE_TIME,
-    kind: FileType::RegularFile,
-    perm: 0o644,
-    nlink: 1,
-    uid: 501,
-    gid: 20,
-    rdev: 0,
-    flags: 0,
-};
+    static ref HELLO_TXT_ATTR: FileAttr = FileAttr {
+        ino: 2,
+        size: 13,
+        blocks: 1,
+        atime: *CREATE_TIME,
+        mtime: *CREATE_TIME,
+        ctime: *CREATE_TIME,
+        crtime: *CREATE_TIME,
+        kind: FileType::RegularFile,
+        perm: 0o644,
+        nlink: 1,
+        uid: 501,
+        gid: 20,
+        rdev: 0,
+        flags: 0,
+    };
+}
 
 struct HelloFS;
 

--- a/fuse/examples/hello.rs
+++ b/fuse/examples/hello.rs
@@ -12,7 +12,7 @@ use fuse::{FileType, FileAttr, Filesystem, Request, ReplyData, ReplyEntry, Reply
 
 lazy_static! {
     // 1 second
-    static ref TTL: Duration = Duration::new(1, 0);
+    static ref TTL: SystemTime = UNIX_EPOCH + Duration::new(1, 0);
 
     // 2013-10-08 08:56
     static ref CREATE_TIME: SystemTime = UNIX_EPOCH + Duration::new(1381237736, 0);

--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -10,7 +10,6 @@ extern crate fuse_sys;
 extern crate libc;
 #[macro_use]
 extern crate log;
-extern crate time;
 extern crate thread_scoped;
 
 use std::convert::AsRef;
@@ -18,7 +17,7 @@ use std::io;
 use std::ffi::OsStr;
 use std::path::Path;
 use libc::{c_int, ENOSYS};
-use time::Timespec;
+use std::time::SystemTime;
 
 pub use fuse_sys::abi::FUSE_ROOT_ID;
 pub use fuse_sys::abi::consts;
@@ -65,13 +64,13 @@ pub struct FileAttr {
     /// Size in blocks
     pub blocks: u64,
     /// Time of last access
-    pub atime: Timespec,
+    pub atime: SystemTime,
     /// Time of last modification
-    pub mtime: Timespec,
+    pub mtime: SystemTime,
     /// Time of last change
-    pub ctime: Timespec,
+    pub ctime: SystemTime,
     /// Time of creation (macOS only)
-    pub crtime: Timespec,
+    pub crtime: SystemTime,
     /// Kind of file (directory, file, pipe, etc)
     pub kind: FileType,
     /// Permissions
@@ -125,7 +124,7 @@ pub trait Filesystem {
     }
 
     /// Set file attributes.
-    fn setattr(&mut self, _req: &Request, _ino: u64, _mode: Option<u32>, _uid: Option<u32>, _gid: Option<u32>, _size: Option<u64>, _atime: Option<Timespec>, _mtime: Option<Timespec>, _fh: Option<u64>, _crtime: Option<Timespec>, _chgtime: Option<Timespec>, _bkuptime: Option<Timespec>, _flags: Option<u32>, reply: ReplyAttr) {
+    fn setattr(&mut self, _req: &Request, _ino: u64, _mode: Option<u32>, _uid: Option<u32>, _gid: Option<u32>, _size: Option<u64>, _atime: Option<SystemTime>, _mtime: Option<SystemTime>, _fh: Option<u64>, _crtime: Option<SystemTime>, _chgtime: Option<SystemTime>, _bkuptime: Option<SystemTime>, _flags: Option<u32>, reply: ReplyAttr) {
         reply.error(ENOSYS);
     }
 

--- a/fuse/src/reply.rs
+++ b/fuse/src/reply.rs
@@ -101,12 +101,12 @@ fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
         ino: attr.ino,
         size: attr.size,
         blocks: attr.blocks,
-        atime: attr.atime.sec,
-        mtime: attr.mtime.sec,
-        ctime: attr.ctime.sec,
-        atimensec: attr.atime.nsec,
-        mtimensec: attr.mtime.nsec,
-        ctimensec: attr.ctime.nsec,
+        atime: attr.atime.sec as u64,
+        mtime: attr.mtime.sec as u64,
+        ctime: attr.ctime.sec as u64,
+        atimensec: attr.atime.nsec as u32,
+        mtimensec: attr.mtime.nsec as u32,
+        ctimensec: attr.ctime.nsec as u32,
         mode: mode_from_kind_and_perm(attr.kind, attr.perm),
         nlink: attr.nlink,
         uid: attr.uid,
@@ -249,10 +249,10 @@ impl ReplyEntry {
         self.reply.ok(&fuse_entry_out {
             nodeid: attr.ino,
             generation: generation,
-            entry_valid: ttl.sec,
-            attr_valid: ttl.sec,
-            entry_valid_nsec: ttl.nsec,
-            attr_valid_nsec: ttl.nsec,
+            entry_valid: ttl.sec as u64,
+            attr_valid: ttl.sec as u64,
+            entry_valid_nsec: ttl.nsec as u32,
+            attr_valid_nsec: ttl.nsec as u32,
             attr: fuse_attr_from_attr(attr),
         });
     }
@@ -281,8 +281,8 @@ impl ReplyAttr {
     /// Reply to a request with the given attribute
     pub fn attr(self, ttl: &Timespec, attr: &FileAttr) {
         self.reply.ok(&fuse_attr_out {
-            attr_valid: ttl.sec,
-            attr_valid_nsec: ttl.nsec,
+            attr_valid: ttl.sec as u64,
+            attr_valid_nsec: ttl.nsec as u32,
             dummy: 0,
             attr: fuse_attr_from_attr(attr),
         });
@@ -446,10 +446,10 @@ impl ReplyCreate {
         self.reply.ok(&(fuse_entry_out {
             nodeid: attr.ino,
             generation: generation,
-            entry_valid: ttl.sec,
-            attr_valid: ttl.sec,
-            entry_valid_nsec: ttl.nsec,
-            attr_valid_nsec: ttl.nsec,
+            entry_valid: ttl.sec as u64,
+            attr_valid: ttl.sec as u64,
+            entry_valid_nsec: ttl.nsec as u32,
+            attr_valid_nsec: ttl.nsec as u32,
             attr: fuse_attr_from_attr(attr),
         }, fuse_open_out {
             fh: fh,

--- a/fuse/src/reply.rs
+++ b/fuse/src/reply.rs
@@ -55,8 +55,8 @@ fn as_bytes<T, U, F: FnOnce(&[&[u8]]) -> U>(data: &T, f: F) -> U {
 }
 
 fn time_from_system_time(system_time: &SystemTime) -> Result<(u64, u32), SystemTimeError> {
-    let duration_since = system_time.duration_since(UNIX_EPOCH)?;
-    Ok((duration_since.as_secs(), duration_since.subsec_nanos()))
+    let duration = system_time.duration_since(UNIX_EPOCH)?;
+    Ok((duration.as_secs(), duration.subsec_nanos()))
 }
 
 // Some platforms like Linux x86_64 have mode_t = u32, and lint warns of a trivial_numeric_casts.

--- a/fuse/src/request.rs
+++ b/fuse/src/request.rs
@@ -177,11 +177,11 @@ impl<'a> Request<'a> {
                 };
                 let atime = match arg.valid & FATTR_ATIME {
                     0 => None,
-                    _ => Some(Timespec::new(arg.atime, arg.atimensec)),
+                    _ => Some(Timespec::new(arg.atime as i64, arg.atimensec as i32)),
                 };
                 let mtime = match arg.valid & FATTR_MTIME {
                     0 => None,
-                    _ => Some(Timespec::new(arg.mtime, arg.mtimensec)),
+                    _ => Some(Timespec::new(arg.mtime as i64, arg.mtimensec as i32)),
                 };
                 let fh = match arg.valid & FATTR_FH {
                     0 => None,


### PR DESCRIPTION
Fixes #87 

This required also changing the types from signed integers to unsigned integers in the `fuse-sys` crate (see commits).

NOTE: ~~at the moment some tests aren't passing, I'm not entirely sure why (mostly because I don't understand exactly what they're testing). Any chance you can point me in the right direction?~~ I've fixed the tests, but have a few questions. If you could have a look at my comments and explain some things to me that would be awesome.