### PR TITLE
Make unmount public

### DIFF
--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use libc::{c_int, ENOSYS};
 use time::Timespec;
 
+pub use channel::unmount;
 pub use fuse_sys::abi::FUSE_ROOT_ID;
 pub use fuse_sys::abi::consts;
 pub use reply::{Reply, ReplyEmpty, ReplyData, ReplyEntry, ReplyAttr, ReplyOpen};


### PR DESCRIPTION
Unmounting a file system in different platforms is a difficult task, but
fortunately such code already exists within fuse::channel::unmount.
Expose this function as fuse::unmount.

Access to unmount is useful to asynchronously tell the fuse loop to stop.