### PR TITLE
Correct offset handling in readdir example

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -81,12 +81,9 @@ impl Filesystem for HelloFS {
             (2, FileType::RegularFile, "hello.txt"),
         ];
 
-        // Offset of 0 means no offset.
-        // Non-zero offset means the passed offset has already been seen, and we should start after
-        // it.
-        let to_skip = if offset == 0 { offset } else { offset + 1 } as usize;
-        for (i, entry) in entries.into_iter().enumerate().skip(to_skip) {
-            reply.add(entry.0, i as i64, entry.1, entry.2);
+        for (i, entry) in entries.into_iter().enumerate().skip(offset as usize) {
+            // i + 1 means the index of the next entry
+            reply.add(entry.0, (i + 1) as i64, entry.1, entry.2);
         }
         reply.ok();
     }


### PR DESCRIPTION
I am using libfuse (fuse_lowleve_ops) documentation as the reference, assuming both rust-fuse and libfuse are thin layers on top of the data communication without altering values like +1 or -1.

The [doc of `fuse_add_direntry`](https://libfuse.github.io/doxygen/fuse__lowlevel_8h.html#ad1957bcc8ece8c90f16c42c4daf3053f) (assuming equivalent to ReplyDirectory::add) states that `off` (`offset`) is the offset of the *next* entry, and it does not need to be the actual physical position (read: an element index of a continuous array). This value is passed to the next `readdir` call as the `offset` parameter. According to the [doc of `readdir`](https://libfuse.github.io/doxygen/structfuse__lowlevel__ops.html#a65b7d7fc14d3958d7fb7d215fda20301), "readdir() should skip over entries coming *before* the position defined by the off_t value." (read: the entry defined *at* `offset` should be returned in this call). The most intuitive design, when the entry forms a continuous array, is to use the `offset` as the index of the first entry that is going to be read in {the next call} (for `reply.add`) / {this call} (for `readdir`). This code change is to adopt this intuitive design.

The old code is not completely wrong. It almost works, but in a different way, which exploits the fact that "offset does not need to be the actual physical position". Here are two tables showing how exactly the old and the new approach work

The old code: 

| last index of element written to `reply.add` | last `offset` written to `reply.add` | `offset` passed to the next `readdir` | index of the first element to write in the next `readdir`|
|---|---|---|---|
| 0 | 0 | 0 | 0 (bug)|
| 1 | 1 | 1 | 2|
| 2 | 2 | 2 | 3|
| 3 | 3 | 3 | 4|

The new code:

| last index of element written to `reply.add` | last `offset` written to `reply.add` | `offset` passed to the next `readdir` | index of the first element to write in the next `readdir`|
|---|---|---|---|
| 0 | 1 | 1 | 1 |
| 1 | 2 | 2 | 2 |
| 2 | 3 | 3 | 3|
| 3 | 4 | 4 | 4|

As shown in the table, the old code would give wrong result if the first `readdir` only read one entry at 0. This bug wasn't caught probably because callers rarely only read one entry for one call.