### PR TITLE
Allow delegating all linking

### DIFF
--- a/fuse-sys/build.rs
+++ b/fuse-sys/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 #[cfg(not(target_os = "macos"))]
 static LIBFUSE_NAME: &str = "fuse";
 
@@ -5,5 +7,12 @@ static LIBFUSE_NAME: &str = "fuse";
 static LIBFUSE_NAME: &str = "osxfuse";
 
 fn main () {
+    let k = "FUSE_SYS_DELEGATE_LINKING";
+
+    println!("cargo:rerun-if-env-changed={}", k);
+    if env::var(k).is_ok() {
+        return;
+    }
+
     pkg_config::Config::new().atleast_version("2.6.0").probe(LIBFUSE_NAME).unwrap();
 }


### PR DESCRIPTION
This is necessary when an external build system (e.g. Buck) is taking
care of linking in libfuse, and we don't want the Rust compiler to emit
any linking arguments.