### PR TITLE
WIP: Update fuse mount methods to take AsRef<OsStr> as options

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -92,9 +92,6 @@ impl Filesystem for HelloFS {
 fn main() {
     env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
-    let options = ["-o", "ro", "-o", "fsname=hello"]
-        .iter()
-        .map(|o| o.as_ref())
-        .collect::<Vec<&OsStr>>();
+    let options = OsStr::new("-o ro -o fsname=hello");
     fuse::mount(HelloFS, mountpoint, &options).unwrap();
 }

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -8,5 +8,6 @@ impl Filesystem for NullFS {}
 fn main() {
     env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
-    fuse::mount(NullFS, mountpoint, &[]).unwrap();
+
+    fuse::mount(NullFS, mountpoint, &"").unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,8 +367,8 @@ pub trait Filesystem {
 ///
 /// Note that you need to lead each option with a separate `"-o"` string. See
 /// `examples/hello.rs`.
-pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr]) -> io::Result<()>{
-    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|mut se| se.run())
+pub fn mount<FS: Filesystem, P: AsRef<Path>, O: AsRef<OsStr>>(filesystem: FS, mountpoint: P, options: O) -> io::Result<()> {
+    Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|mut se| se.run())
 }
 
 /// Mount the given filesystem to the given mountpoint. This function spawns
@@ -376,6 +376,6 @@ pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: P, opti
 /// and therefore returns immediately. The returned handle should be stored
 /// to reference the mounted filesystem. If it's dropped, the filesystem will
 /// be unmounted.
-pub unsafe fn spawn_mount<'a, FS: Filesystem+Send+'a, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr]) -> io::Result<BackgroundSession<'a>> {
-    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn())
+pub unsafe fn spawn_mount<'a, FS: Filesystem+Send+'a, P: AsRef<Path>, O: AsRef<OsStr>>(filesystem: FS, mountpoint: P, options: O) -> io::Result<BackgroundSession<'a>> {
+    Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|se| se.spawn())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -45,7 +45,7 @@ pub struct Session<FS: Filesystem> {
 
 impl<FS: Filesystem> Session<FS> {
     /// Create a new session by mounting the given filesystem to the given mountpoint
-    pub fn new(filesystem: FS, mountpoint: &Path, options: &[&OsStr]) -> io::Result<Session<FS>> {
+    pub fn new(filesystem: FS, mountpoint: &Path, options: &OsStr) -> io::Result<Session<FS>> {
         info!("Mounting {}", mountpoint.display());
         Channel::new(mountpoint, options).map(|ch| {
             Session {


### PR DESCRIPTION
Update fuse::mount and fuse::spawn_mount to take generic AsRef<OsStr>
as options argument.

Fixes #117