### PR TITLE
139: Allow for configuring `max_write`

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -96,5 +96,5 @@ fn main() {
         .iter()
         .map(|o| o.as_ref())
         .collect::<Vec<&OsStr>>();
-    fuse::mount(HelloFS, mountpoint, &options).unwrap();
+    fuse::mount(HelloFS, mountpoint, &options, None).unwrap();
 }

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -8,5 +8,5 @@ impl Filesystem for NullFS {}
 fn main() {
     env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
-    fuse::mount(NullFS, mountpoint, &[]).unwrap();
+    fuse::mount(NullFS, mountpoint, &[], None).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,8 +367,8 @@ pub trait Filesystem {
 ///
 /// Note that you need to lead each option with a separate `"-o"` string. See
 /// `examples/hello.rs`.
-pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr]) -> io::Result<()>{
-    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|mut se| se.run())
+pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr], requested_write_size: Option<usize>) -> io::Result<()>{
+    Session::new(filesystem, mountpoint.as_ref(), options, requested_write_size).and_then(|mut se| se.run())
 }
 
 /// Mount the given filesystem to the given mountpoint. This function spawns
@@ -376,6 +376,6 @@ pub fn mount<FS: Filesystem, P: AsRef<Path>>(filesystem: FS, mountpoint: P, opti
 /// and therefore returns immediately. The returned handle should be stored
 /// to reference the mounted filesystem. If it's dropped, the filesystem will
 /// be unmounted.
-pub unsafe fn spawn_mount<'a, FS: Filesystem+Send+'a, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr]) -> io::Result<BackgroundSession<'a>> {
-    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn())
+pub unsafe fn spawn_mount<'a, FS: Filesystem+Send+'a, P: AsRef<Path>>(filesystem: FS, mountpoint: P, options: &[&OsStr], requested_write_size: Option<usize>) -> io::Result<BackgroundSession<'a>> {
+    Session::new(filesystem, mountpoint.as_ref(), options, requested_write_size).and_then(|se| se.spawn())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,11 +20,11 @@ use crate::Filesystem;
 /// The max size of write requests from the kernel. The absolute minimum is 4k,
 /// FUSE recommends at least 128k, max 16M. The FUSE default is 16M on macOS
 /// and 128k on other systems.
-pub const MAX_WRITE_SIZE: usize = 16 * 1024 * 1024;
+const MAX_WRITE_SIZE: usize = 16 * 1024 * 1024;
 
 /// Size of the buffer for reading a request from the kernel. Since the kernel may send
 /// up to MAX_WRITE_SIZE bytes in a write request, we use that value plus some extra space.
-const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
+//const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
 
 /// The session data structure
 #[derive(Debug)]
@@ -41,11 +41,13 @@ pub struct Session<FS: Filesystem> {
     pub initialized: bool,
     /// True if the filesystem was destroyed (destroy operation done)
     pub destroyed: bool,
+    /// Requested write size for setting max_write
+    pub requested_write_size: usize,
 }
 
 impl<FS: Filesystem> Session<FS> {
     /// Create a new session by mounting the given filesystem to the given mountpoint
-    pub fn new(filesystem: FS, mountpoint: &Path, options: &[&OsStr]) -> io::Result<Session<FS>> {
+    pub fn new(filesystem: FS, mountpoint: &Path, options: &[&OsStr], requested_write_size: Option<usize>) -> io::Result<Session<FS>> {
         info!("Mounting {}", mountpoint.display());
         Channel::new(mountpoint, options).map(|ch| {
             Session {
@@ -55,6 +57,10 @@ impl<FS: Filesystem> Session<FS> {
                 proto_minor: 0,
                 initialized: false,
                 destroyed: false,
+                requested_write_size: match requested_write_size {
+                    None => MAX_WRITE_SIZE,
+                    Some(size) => size,
+                },
             }
         })
     }
@@ -69,14 +75,18 @@ impl<FS: Filesystem> Session<FS> {
     /// having multiple buffers (which take up much memory), but the filesystem methods
     /// may run concurrent by spawning threads.
     pub fn run(&mut self) -> io::Result<()> {
+        // Size of the buffer for reading a request from the kernel. Since the kernel may send
+        // up to self.requested_write_size bytes in a write request, we use that value plus
+        // some extra space.
+        let buffer_size = self.requested_write_size + 4096;
         // Buffer for receiving requests from the kernel. Only one is allocated and
         // it is reused immediately after dispatching to conserve memory and allocations.
-        let mut buffer: Vec<u8> = Vec::with_capacity(BUFFER_SIZE);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
         loop {
             // Read the next request from the given channel to kernel driver
             // The kernel driver makes sure that we get exactly one request per read
             match self.ch.receive(&mut buffer) {
-                Ok(()) => match Request::new(self.ch.sender(), &buffer) {
+                Ok(()) => match Request::new(self.ch.sender(), &buffer, buffer_size) {
                     // Dispatch request
                     Some(req) => req.dispatch(self),
                     // Quit loop on illegal request


### PR DESCRIPTION
This patch allows one to provide a different value for setting `max_write` which can be useful for some use cases.

This patch does change the API of `mount` and `spawn_mount`. Given the existing API, I wasn't sure how else to introduce this feature.

Feedback is welcome.