### PR TITLE
Update MacOs compatibility to use more recent FUSE extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libfuse-dev pkg-config
       - name: Install FUSE (macOS)
         if: startsWith(matrix.os, 'macos')
-        run: brew update && brew install pkg-config && brew tap homebrew/cask && brew cask install osxfuse
+        run: brew update && brew install pkg-config && brew tap homebrew/cask && brew install --cask macfuse
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Installer packages can be downloaded from the [FUSE for macOS homepage][FUSE for
 To install using [Homebrew]:
 
 ```sh
-brew cask install osxfuse
+brew install --cask macfuse
 ```
 
 To install `pkg-config` (required for building only):

--- a/fuse-sys/build.rs
+++ b/fuse-sys/build.rs
@@ -1,8 +1,4 @@
-#[cfg(not(target_os = "macos"))]
 const LIBFUSE_NAME: &str = "fuse";
-
-#[cfg(target_os = "macos")]
-const LIBFUSE_NAME: &str = "osxfuse";
 
 fn main() {
     pkg_config::Config::new()


### PR DESCRIPTION
The cask `osxfuse` is still on version 3.x of the library. This is pretty outdated, since there's already a 4.0.5. I updated the README to use another cask called `macfuse` which corresponds to the newer version of osxfuse. It seems that while moving up in versions, they also changed the library package name to "fuse" as on other platforms, instead of the previous "osxfuse". Hence, I also updated the `build.rs` file to be able to build on the newer version.

Instead of just changing the name, we could also implement a check for both names: `osxfuse` and `fuse` when building on MacOS. I am happy to adapt this PR if you want.
With this new library version, the crate builds perfectly fine on the new Apple Silicon MacBooks 👍 