### PR TITLE
Modified the build to be inline with osxfuse to macfuse transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Installer packages can be downloaded from the [FUSE for macOS homepage][FUSE for
 To install using [Homebrew]:
 
 ```sh
-brew cask install osxfuse
+brew cask install macfuse
 ```
 
 To install `pkg-config` (required for building only):

--- a/fuse-sys/build.rs
+++ b/fuse-sys/build.rs
@@ -1,8 +1,4 @@
-#[cfg(not(target_os = "macos"))]
 const LIBFUSE_NAME: &str = "fuse";
-
-#[cfg(target_os = "macos")]
-const LIBFUSE_NAME: &str = "osxfuse";
 
 fn main() {
     pkg_config::Config::new()


### PR DESCRIPTION
The macfuse build process is more inline with Linux and FreeBSD build. The package name is fuse. This has reduced the conditional instruction in Mac. 

Still a TODO on supporting both osxfuse and macfuse together. 