### PR TITLE
The Mac OS builds of Fuse have transitioned to macfuse

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ task:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock || echo ""
   setup_script:
-    - brew install rust gcc curl
+    - brew install gcc curl
     - brew install --cask macfuse
     - curl https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,8 +30,10 @@ task:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock || echo ""
   setup_script:
-    - brew install rust gcc
+    - brew install rust gcc curl
     - brew install --cask macfuse
+    - curl https://sh.rustup.rs -o rustup.sh
+    - sh rustup.sh -y
   build_script:
     - . $HOME/.cargo/env
     - cargo build --all --all-targets

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ task:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock || echo ""
   setup_script:
-    - brew install rust clang gcc
+    - brew install rust gcc
     - brew install --cask macfuse
   build_script:
     - . $HOME/.cargo/env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,3 +20,25 @@ task:
     - . $HOME/.cargo/env
     - cargo test --all --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+
+task:
+  name: Mac OS X Monterey
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock || echo ""
+  setup_script:
+    - brew install rust clang gcc
+    - brew install --cask macfuse
+  build_script:
+    - . $HOME/.cargo/env
+    - cargo build --all --all-targets
+  doc_script:
+    - . $HOME/.cargo/env
+    - cargo doc --all --no-deps --all-features
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test --all --all-targets
+  before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/fuse-sys/build.rs
+++ b/fuse-sys/build.rs
@@ -1,9 +1,9 @@
-#[cfg(not(target_os = "macos"))]
+/*#[cfg(not(target_os = "macos"))]*/
 const LIBFUSE_NAME: &str = "fuse";
 
-#[cfg(target_os = "macos")]
+/*#[cfg(target_os = "macos")]
 const LIBFUSE_NAME: &str = "osxfuse";
-
+*/
 fn main() {
     pkg_config::Config::new()
         .atleast_version("2.6.0")

--- a/fuse-sys/build.rs
+++ b/fuse-sys/build.rs
@@ -1,9 +1,5 @@
-/*#[cfg(not(target_os = "macos"))]*/
 const LIBFUSE_NAME: &str = "fuse";
 
-/*#[cfg(target_os = "macos")]
-const LIBFUSE_NAME: &str = "osxfuse";
-*/
 fn main() {
     pkg_config::Config::new()
         .atleast_version("2.6.0")


### PR DESCRIPTION
This changes the naming convention. The library follows same naming convention as Linux libfuse. The build does not need to make exception for Mac OS target