### PR TITLE
Version fix on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Put this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fuse = "0.4"
+fuse = "0.3.1"
 ```
 
 To create a new filesystem, implement the trait `fuse::Filesystem`. See the [documentation] for details or the `examples` directory for some basic examples.


### PR DESCRIPTION
Version 4.0 is not released for a while, it's better to keep it `0.3.1` which is the latest stable release